### PR TITLE
fix(auth): handle passwordless OAuth users across password-dependent features

### DIFF
--- a/app/Http/Controllers/Settings/PasswordController.php
+++ b/app/Http/Controllers/Settings/PasswordController.php
@@ -11,17 +11,24 @@ use Inertia\Response;
 
 class PasswordController extends Controller
 {
-    public function edit(): Response
+    public function edit(Request $request): Response
     {
-        return Inertia::render('settings/password');
+        return Inertia::render('settings/password', [
+            'hasPassword' => $request->user()?->has_password,
+        ]);
     }
 
     public function update(Request $request): RedirectResponse
     {
-        $validated = $request->validate([
-            'current_password' => ['required', 'current_password'],
+        $rules = [
             'password' => ['required', Password::defaults(), 'confirmed'],
-        ]);
+        ];
+
+        if ($request->user()?->has_password) {
+            $rules['current_password'] = ['required', 'current_password'];
+        }
+
+        $validated = $request->validate($rules);
 
         $request->user()?->update([
             'password' => $validated['password'],

--- a/app/Http/Controllers/Settings/ProfileController.php
+++ b/app/Http/Controllers/Settings/ProfileController.php
@@ -36,9 +36,11 @@ class ProfileController extends Controller
 
     public function destroy(Request $request): RedirectResponse
     {
-        $request->validate([
-            'password' => ['required', 'current_password'],
-        ]);
+        if ($request->user()?->has_password) {
+            $request->validate([
+                'password' => ['required', 'current_password'],
+            ]);
+        }
 
         $user = $request->user();
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -80,7 +80,7 @@ class User extends Authenticatable implements MustVerifyEmail
     /**
      * @var list<string>
      */
-    protected $appends = ['avatar'];
+    protected $appends = ['avatar', 'has_password'];
 
     /**
      * @var list<string>
@@ -172,6 +172,16 @@ class User extends Authenticatable implements MustVerifyEmail
         $preferences['dismissed_onboarding'] = $dismissed;
         $this->preferences = $preferences;
         $this->save();
+    }
+
+    /**
+     * @return Attribute<bool, never>
+     */
+    protected function hasPassword(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => $this->password !== null,
+        );
     }
 
     /**

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -57,6 +57,16 @@ class UserFactory extends Factory
     }
 
     /**
+     * Indicate that the user signed up via OAuth and has no password.
+     */
+    public function withoutPassword(): static
+    {
+        return $this->withGitHub()->state(fn (array $attributes) => [
+            'password' => null,
+        ]);
+    }
+
+    /**
      * Indicate that the user has a connected GitHub account.
      */
     public function withGitHub(): static

--- a/resources/js/components/delete-user.tsx
+++ b/resources/js/components/delete-user.tsx
@@ -13,10 +13,12 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Form } from '@inertiajs/react';
+import { SharedData } from '@/types';
+import { Form, usePage } from '@inertiajs/react';
 import { useRef } from 'react';
 
 export default function DeleteUser() {
+    const { has_password } = usePage<SharedData>().props.auth.user;
     const passwordInput = useRef<HTMLInputElement>(null);
 
     return (
@@ -47,10 +49,9 @@ export default function DeleteUser() {
                             Are you sure you want to delete your account?
                         </DialogTitle>
                         <DialogDescription>
-                            Once your account is deleted, all of its resources
-                            and data will also be permanently deleted. Please
-                            enter your password to confirm you would like to
-                            permanently delete your account.
+                            {has_password
+                                ? 'Once your account is deleted, all of its resources and data will also be permanently deleted. Please enter your password to confirm you would like to permanently delete your account.'
+                                : 'Once your account is deleted, all of its resources and data will also be permanently deleted.'}
                         </DialogDescription>
 
                         <Form
@@ -64,25 +65,29 @@ export default function DeleteUser() {
                         >
                             {({ resetAndClearErrors, processing, errors }) => (
                                 <>
-                                    <div className="grid gap-2">
-                                        <Label
-                                            htmlFor="password"
-                                            className="sr-only"
-                                        >
-                                            Password
-                                        </Label>
+                                    {has_password && (
+                                        <div className="grid gap-2">
+                                            <Label
+                                                htmlFor="password"
+                                                className="sr-only"
+                                            >
+                                                Password
+                                            </Label>
 
-                                        <Input
-                                            id="password"
-                                            type="password"
-                                            name="password"
-                                            ref={passwordInput}
-                                            placeholder="Password"
-                                            autoComplete="current-password"
-                                        />
+                                            <Input
+                                                id="password"
+                                                type="password"
+                                                name="password"
+                                                ref={passwordInput}
+                                                placeholder="Password"
+                                                autoComplete="current-password"
+                                            />
 
-                                        <InputError message={errors.password} />
-                                    </div>
+                                            <InputError
+                                                message={errors.password}
+                                            />
+                                        </div>
+                                    )}
 
                                     <DialogFooter className="gap-2">
                                         <DialogClose asChild>

--- a/resources/js/pages/auth/confirm-password.tsx
+++ b/resources/js/pages/auth/confirm-password.tsx
@@ -7,11 +7,19 @@ import AuthLayout from '@/layouts/auth-layout';
 import { store } from '@/routes/password/confirm';
 import { Form, Head } from '@inertiajs/react';
 
-export default function ConfirmPassword() {
+export default function ConfirmPassword({
+    hasPassword,
+}: {
+    hasPassword: boolean;
+}) {
     return (
         <AuthLayout
             title="Confirm your password"
-            description="This is a secure area of the application. Please confirm your password before continuing."
+            description={
+                hasPassword
+                    ? 'This is a secure area of the application. Please confirm your password before continuing.'
+                    : 'This is a secure area of the application. Please confirm to continue.'
+            }
         >
             <Head title="Confirm password" />
 
@@ -22,19 +30,21 @@ export default function ConfirmPassword() {
             >
                 {({ processing, errors }) => (
                     <div className="space-y-6">
-                        <div className="grid gap-2">
-                            <Label htmlFor="password">Password</Label>
-                            <Input
-                                id="password"
-                                type="password"
-                                name="password"
-                                placeholder="Password"
-                                autoComplete="current-password"
-                                autoFocus
-                            />
+                        {hasPassword && (
+                            <div className="grid gap-2">
+                                <Label htmlFor="password">Password</Label>
+                                <Input
+                                    id="password"
+                                    type="password"
+                                    name="password"
+                                    placeholder="Password"
+                                    autoComplete="current-password"
+                                    autoFocus
+                                />
 
-                            <InputError message={errors.password} />
-                        </div>
+                                <InputError message={errors.password} />
+                            </div>
+                        )}
 
                         <div className="flex items-center">
                             <Button
@@ -43,7 +53,9 @@ export default function ConfirmPassword() {
                                 data-test="confirm-password-button"
                             >
                                 {processing && <Spinner />}
-                                Confirm password
+                                {hasPassword
+                                    ? 'Confirm password'
+                                    : 'Continue'}
                             </Button>
                         </div>
                     </div>

--- a/resources/js/pages/auth/login.tsx
+++ b/resources/js/pages/auth/login.tsx
@@ -6,10 +6,11 @@ import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
 import { Spinner } from '@/components/ui/spinner';
 import AuthLayout from '@/layouts/auth-layout';
+import { SharedData } from '@/types';
 import { register } from '@/routes';
 import { store } from '@/routes/login';
 import { request } from '@/routes/password';
-import { Form, Head } from '@inertiajs/react';
+import { Form, Head, usePage } from '@inertiajs/react';
 
 interface LoginProps {
     status?: string;
@@ -24,6 +25,8 @@ export default function Login({
     canRegister,
     githubEnabled,
 }: LoginProps) {
+    const { flash } = usePage<SharedData>().props;
+
     return (
         <AuthLayout
             title="Log in to your account"
@@ -124,6 +127,12 @@ export default function Login({
                     </>
                 )}
             </Form>
+
+            {flash?.error && (
+                <div className="text-center text-sm font-medium text-red-600">
+                    {flash.error}
+                </div>
+            )}
 
             {status && (
                 <div className="text-center text-sm font-medium text-green-600">

--- a/resources/js/pages/settings/password.tsx
+++ b/resources/js/pages/settings/password.tsx
@@ -25,7 +25,7 @@ const breadcrumbs: BreadcrumbItem[] = [
     },
 ];
 
-export default function Password() {
+export default function Password({ hasPassword }: { hasPassword: boolean }) {
     const passwordInput = useRef<HTMLInputElement>(null);
     const currentPasswordInput = useRef<HTMLInputElement>(null);
 
@@ -36,7 +36,9 @@ export default function Password() {
             <SettingsLayout>
                 <div className="space-y-6">
                     <HeadingSmall
-                        title="Update password"
+                        title={
+                            hasPassword ? 'Update password' : 'Set password'
+                        }
                         description="Ensure your account is using a long, random password to stay secure"
                     />
 
@@ -64,29 +66,33 @@ export default function Password() {
                     >
                         {({ errors, processing, recentlySuccessful }) => (
                             <>
-                                <div className="grid gap-2">
-                                    <Label htmlFor="current_password">
-                                        Current password
-                                    </Label>
+                                {hasPassword && (
+                                    <div className="grid gap-2">
+                                        <Label htmlFor="current_password">
+                                            Current password
+                                        </Label>
 
-                                    <Input
-                                        id="current_password"
-                                        ref={currentPasswordInput}
-                                        name="current_password"
-                                        type="password"
-                                        className="mt-1 block w-full"
-                                        autoComplete="current-password"
-                                        placeholder="Current password"
-                                    />
+                                        <Input
+                                            id="current_password"
+                                            ref={currentPasswordInput}
+                                            name="current_password"
+                                            type="password"
+                                            className="mt-1 block w-full"
+                                            autoComplete="current-password"
+                                            placeholder="Current password"
+                                        />
 
-                                    <InputError
-                                        message={errors.current_password}
-                                    />
-                                </div>
+                                        <InputError
+                                            message={errors.current_password}
+                                        />
+                                    </div>
+                                )}
 
                                 <div className="grid gap-2">
                                     <Label htmlFor="password">
-                                        New password
+                                        {hasPassword
+                                            ? 'New password'
+                                            : 'Password'}
                                     </Label>
 
                                     <Input
@@ -96,7 +102,11 @@ export default function Password() {
                                         type="password"
                                         className="mt-1 block w-full"
                                         autoComplete="new-password"
-                                        placeholder="New password"
+                                        placeholder={
+                                            hasPassword
+                                                ? 'New password'
+                                                : 'Password'
+                                        }
                                     />
 
                                     <InputError message={errors.password} />
@@ -126,7 +136,9 @@ export default function Password() {
                                         disabled={processing}
                                         data-test="update-password-button"
                                     >
-                                        Save password
+                                        {hasPassword
+                                            ? 'Save password'
+                                            : 'Set password'}
                                     </Button>
 
                                     <Transition

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -61,6 +61,7 @@ export interface User {
     avatar_url?: string | null;
     github_nickname?: string | null;
     has_github_connected?: boolean;
+    has_password: boolean;
     email_verified_at: string | null;
     two_factor_enabled?: boolean;
     created_at: string;

--- a/tests/Feature/Auth/PasswordConfirmationTest.php
+++ b/tests/Feature/Auth/PasswordConfirmationTest.php
@@ -12,6 +12,7 @@ test('confirm password screen can be rendered', function () {
 
     $response->assertInertia(fn (Assert $page) => $page
         ->component('auth/confirm-password')
+        ->where('hasPassword', true)
     );
 });
 
@@ -19,4 +20,27 @@ test('password confirmation requires authentication', function () {
     $response = $this->get(route('password.confirm'));
 
     $response->assertRedirect(route('login'));
+});
+
+test('oauth user can confirm without entering a password', function () {
+    $user = User::factory()->withoutPassword()->create();
+
+    $response = $this->actingAs($user)
+        ->post(route('password.confirm.store'), [
+            'password' => '',
+        ]);
+
+    $response->assertRedirect();
+    $response->assertSessionHasNoErrors();
+});
+
+test('confirm password page returns hasPassword false for oauth user', function () {
+    $user = User::factory()->withoutPassword()->create();
+
+    $this->actingAs($user)
+        ->get(route('password.confirm'))
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('auth/confirm-password')
+            ->where('hasPassword', false)
+        );
 });

--- a/tests/Feature/Settings/PasswordUpdateTest.php
+++ b/tests/Feature/Settings/PasswordUpdateTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
+use Inertia\Testing\AssertableInertia as Assert;
 
 test('password update page is displayed', function () {
     $user = User::factory()->create();
@@ -47,4 +48,44 @@ test('correct password must be provided to update password', function () {
     $response
         ->assertSessionHasErrors('current_password')
         ->assertRedirect(route('user-password.edit'));
+});
+
+test('oauth user can set password without current password', function () {
+    $user = User::factory()->withoutPassword()->create();
+
+    $response = $this
+        ->actingAs($user)
+        ->from(route('user-password.edit'))
+        ->put(route('user-password.update'), [
+            'password' => 'new-password',
+            'password_confirmation' => 'new-password',
+        ]);
+
+    $response
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(route('user-password.edit'));
+
+    expect(Hash::check('new-password', $user->refresh()->password))->toBeTrue();
+});
+
+test('password page returns hasPassword false for oauth user', function () {
+    $user = User::factory()->withoutPassword()->create();
+
+    $this->actingAs($user)
+        ->get(route('user-password.edit'))
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('settings/password')
+            ->where('hasPassword', false)
+        );
+});
+
+test('password page returns hasPassword true for regular user', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('user-password.edit'))
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('settings/password')
+            ->where('hasPassword', true)
+        );
 });

--- a/tests/Feature/Settings/ProfileUpdateTest.php
+++ b/tests/Feature/Settings/ProfileUpdateTest.php
@@ -82,3 +82,17 @@ test('correct password must be provided to delete account', function () {
 
     expect($user->fresh())->not->toBeNull();
 });
+
+test('oauth user can delete account without password', function () {
+    $user = User::factory()->withoutPassword()->create();
+
+    $response = $this
+        ->actingAs($user)
+        ->delete(route('profile.destroy'));
+
+    $response->assertSessionHasNoErrors();
+    $response->assertRedirect(route('login'));
+
+    $this->assertGuest();
+    expect($user->fresh())->toBeNull();
+});

--- a/tests/Feature/Settings/TwoFactorAuthenticationTest.php
+++ b/tests/Feature/Settings/TwoFactorAuthenticationTest.php
@@ -77,3 +77,23 @@ test('two factor settings page returns forbidden response when two factor is dis
         ->get(route('two-factor.show'))
         ->assertForbidden();
 });
+
+test('oauth user can pass password confirmation for two factor', function () {
+    if (! Features::canManageTwoFactorAuthentication()) {
+        $this->markTestSkipped('Two-factor authentication is not enabled.');
+    }
+
+    Features::twoFactorAuthentication([
+        'confirm' => true,
+        'confirmPassword' => true,
+    ]);
+
+    $user = User::factory()->withoutPassword()->withoutTwoFactor()->create();
+
+    $this->actingAs($user)
+        ->post(route('password.confirm.store'), [
+            'password' => '',
+        ])
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+});


### PR DESCRIPTION
## Summary

- Add `has_password` attribute to User model, exposed to frontend via Inertia shared data
- Skip password validation when deleting account for OAuth users without a password
- Allow OAuth users to set an initial password without providing `current_password`
- Auto-confirm password for passwordless users in Fortify's `password.confirm` middleware (fixes 2FA setup)
- Adapt frontend (delete account dialog, password settings, confirm password page) to conditionally show/hide password fields
- Show `flash.error` messages on the login page (fixes OAuth registration-closed error not being visible)
- Add `withoutPassword()` factory state and comprehensive tests for all OAuth user flows