### PR TITLE
feat: hide UI elements for users without access

### DIFF
--- a/app/Domains/Organization/Contracts/Data/OrganizationData.php
+++ b/app/Domains/Organization/Contracts/Data/OrganizationData.php
@@ -14,6 +14,7 @@ class OrganizationData extends Data
         public string $name,
         public string $slug,
         public string $ownerUuid,
+        public ?OrganizationPermissionsData $permissions = null,
     ) {}
 
     public static function fromModel(Organization $organization): self

--- a/app/Domains/Organization/Contracts/Data/OrganizationPermissionsData.php
+++ b/app/Domains/Organization/Contracts/Data/OrganizationPermissionsData.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Domains\Organization\Contracts\Data;
+
+use App\Models\Organization;
+use App\Models\User;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+class OrganizationPermissionsData extends Data
+{
+    public function __construct(
+        public bool $canViewSettings,
+        public bool $canManageMembers,
+        public bool $canDeleteOrganization,
+        public bool $canUpdateSlug,
+        public bool $canManageRepository,
+    ) {}
+
+    public static function fromUserAndOrganization(User $user, Organization $organization): self
+    {
+        return new self(
+            canViewSettings: $user->can('viewSettings', $organization),
+            canManageMembers: $user->can('manageMembers', $organization),
+            canDeleteOrganization: $user->can('delete', $organization),
+            canUpdateSlug: $user->can('updateSlug', $organization),
+            canManageRepository: $user->can('deleteRepository', $organization),
+        );
+    }
+}

--- a/app/Domains/Repository/Http/Controllers/RepositoryController.php
+++ b/app/Domains/Repository/Http/Controllers/RepositoryController.php
@@ -126,6 +126,7 @@ class RepositoryController extends Controller
             'repository' => RepositoryData::fromModel($repository),
             'packages' => $packages,
             'syncLogs' => $syncLogs,
+            'canManageRepository' => auth()->user()?->can('deleteRepository', $organization) ?? false,
         ]);
     }
 

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use App\Domains\Organization\Contracts\Data\OrganizationData;
+use App\Domains\Organization\Contracts\Data\OrganizationPermissionsData;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 
@@ -43,7 +44,12 @@ class HandleInertiaRequests extends Middleware
             'auth' => [
                 'user' => $request->user(),
                 'organizations' => $request->user()
-                    ? $request->user()->organizations()->get()->map(fn ($org) => OrganizationData::fromModel($org))
+                    ? $request->user()->organizations()->get()->map(function ($org) use ($request) {
+                        $data = OrganizationData::fromModel($org);
+                        $data->permissions = OrganizationPermissionsData::fromUserAndOrganization($request->user(), $org);
+
+                        return $data;
+                    })
                     : [],
             ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -42,11 +42,16 @@ export function AppSidebar() {
         return organizations.length > 0 ? organizations[0].slug : null;
     }, [url, organizations]);
 
+    const currentOrg = useMemo(
+        () => organizations.find((org) => org.slug === currentOrgSlug),
+        [organizations, currentOrgSlug],
+    );
+
     // Build organization-specific navigation
     const orgNavItems: NavItem[] = useMemo(() => {
         if (!currentOrgSlug) return [];
 
-        return [
+        const items: NavItem[] = [
             {
                 title: 'Overview',
                 href: `/organizations/${currentOrgSlug}`,
@@ -62,13 +67,18 @@ export function AppSidebar() {
                 href: `/organizations/${currentOrgSlug}/packages`,
                 icon: Box,
             },
-            {
+        ];
+
+        if (currentOrg?.permissions?.canViewSettings) {
+            items.push({
                 title: 'Settings',
                 href: `/organizations/${currentOrgSlug}/settings/general`,
                 icon: Settings,
-            },
-        ];
-    }, [currentOrgSlug]);
+            });
+        }
+
+        return items;
+    }, [currentOrgSlug, currentOrg]);
 
     return (
         <Sidebar>

--- a/resources/js/pages/organizations/repositories/show.tsx
+++ b/resources/js/pages/organizations/repositories/show.tsx
@@ -49,6 +49,7 @@ interface RepositoryShowProps {
     repository: RepositoryData;
     packages: PackageData[];
     syncLogs: SyncLogData[];
+    canManageRepository: boolean;
 }
 
 function getProviderBadgeColor(provider: string): string {
@@ -94,6 +95,7 @@ export default function RepositoryShow({
     repository,
     packages,
     syncLogs,
+    canManageRepository,
 }: RepositoryShowProps) {
     const { auth } = usePage<{
         auth: { organizations: OrganizationData[] };
@@ -234,18 +236,23 @@ export default function RepositoryShow({
                                         : 'Register Webhook'}
                                 </DropdownMenuItem>
                             )}
-                            <DropdownMenuSeparator />
-                            <DropdownMenuItem asChild>
-                                <Link
-                                    href={edit.url({
-                                        organization: organization.slug,
-                                        repository: repository.uuid,
-                                    })}
-                                >
-                                    <Settings />
-                                    Edit
-                                </Link>
-                            </DropdownMenuItem>
+                            {canManageRepository && (
+                                <>
+                                    <DropdownMenuSeparator />
+                                    <DropdownMenuItem asChild>
+                                        <Link
+                                            href={edit.url({
+                                                organization:
+                                                    organization.slug,
+                                                repository: repository.uuid,
+                                            })}
+                                        >
+                                            <Settings />
+                                            Edit
+                                        </Link>
+                                    </DropdownMenuItem>
+                                </>
+                            )}
                         </DropdownMenuContent>
                     </DropdownMenu>
                 </div>

--- a/resources/types/generated.d.ts
+++ b/resources/types/generated.d.ts
@@ -28,6 +28,7 @@ uuid: string;
 name: string;
 slug: string;
 ownerUuid: string;
+permissions: App.Domains.Organization.Contracts.Data.OrganizationPermissionsData | null;
 };
 export type OrganizationInvitationData = {
 uuid: string;
@@ -44,6 +45,13 @@ name: string;
 email: string;
 role: App.Domains.Organization.Contracts.Enums.OrganizationRole;
 joinedAt: string | null;
+};
+export type OrganizationPermissionsData = {
+canViewSettings: boolean;
+canManageMembers: boolean;
+canDeleteOrganization: boolean;
+canUpdateSlug: boolean;
+canManageRepository: boolean;
 };
 export type OrganizationStatsData = {
 packagesCount: number;


### PR DESCRIPTION
## Summary

- Add `OrganizationPermissionsData` DTO that evaluates `OrganizationPolicy` checks into booleans shared via Inertia
- Hide sidebar "Settings" link for members who lack `canViewSettings` permission
- Hide repository "Edit" action for members who lack `canManageRepository` permission
- Previously these links were always visible, leading to 403 errors when clicked by regular members