### PR TITLE
fix(composer): add dev- prefix to branch version strings

### DIFF
--- a/app/Domains/Repository/Contracts/Data/ComposerMetadataData.php
+++ b/app/Domains/Repository/Contracts/Data/ComposerMetadataData.php
@@ -84,12 +84,18 @@ class ComposerMetadataData extends Data
 
     /**
      * Extract version from reference (tag or branch name).
+     * Branch names are prefixed with "dev-" for Composer compatibility.
      */
     protected static function extractVersion(string $ref): string
     {
         // Remove 'v' prefix if present (e.g., v1.0.0 -> 1.0.0)
         if (str_starts_with($ref, 'v') && preg_match('/^v\d/', $ref)) {
             return substr($ref, 1);
+        }
+
+        // Branch names need dev- prefix for Composer compatibility
+        if (! preg_match('/^\d+\.\d+/', $ref)) {
+            return "dev-{$ref}";
         }
 
         return $ref;
@@ -103,11 +109,6 @@ class ComposerMetadataData extends Data
         $versionParser = new VersionParser;
 
         try {
-            // Handle branch names (e.g., main, develop) as dev versions
-            if (! preg_match('/^\d+\.\d+/', $version)) {
-                return $versionParser->normalize("dev-{$version}");
-            }
-
             return $versionParser->normalize($version);
         } catch (\Exception $e) {
             // If version parsing fails, treat as dev version

--- a/database/migrations/2026_02_25_202834_add_dev_prefix_to_branch_versions.php
+++ b/database/migrations/2026_02_25_202834_add_dev_prefix_to_branch_versions.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Add dev- prefix to branch versions for Composer compatibility.
+     */
+    public function up(): void
+    {
+        DB::table('package_versions')
+            ->where('normalized_version', 'like', 'dev-%')
+            ->where('version', 'not like', 'dev-%')
+            ->update(['version' => DB::raw("CONCAT('dev-', version)")]);
+    }
+
+    /**
+     * Remove dev- prefix from branch versions.
+     */
+    public function down(): void
+    {
+        DB::table('package_versions')
+            ->where('version', 'like', 'dev-%')
+            ->update(['version' => DB::raw("REPLACE(version, 'dev-', '')")]);
+    }
+};

--- a/tests/Unit/ComposerMetadataParserTest.php
+++ b/tests/Unit/ComposerMetadataParserTest.php
@@ -33,9 +33,26 @@ it('parses composer.json with branch name', function () {
 
     $result = ComposerMetadataData::fromComposerJson($composerJson, 'main');
 
-    expect($result->version)->toBe('main')
-        ->and($result->normalizedVersion)->toContain('dev-main');
+    expect($result->version)->toBe('dev-main')
+        ->and($result->normalizedVersion)->toBe('dev-main');
 });
+
+it('adds dev- prefix to non-semver branch names', function (string $ref, string $expectedVersion) {
+    $composerJson = json_encode([
+        'name' => 'vendor/package',
+        'type' => 'library',
+    ]);
+
+    $result = ComposerMetadataData::fromComposerJson($composerJson, $ref);
+
+    expect($result->version)->toBe($expectedVersion);
+})->with([
+    'simple branch' => ['develop', 'dev-develop'],
+    'branch with slash' => ['feature/my-feature', 'dev-feature/my-feature'],
+    'release branch' => ['carconnect-release', 'dev-carconnect-release'],
+    'tag version' => ['v1.0.0', '1.0.0'],
+    'tag without v' => ['1.2.3', '1.2.3'],
+]);
 
 it('throws exception for invalid JSON', function () {
     ComposerMetadataData::fromComposerJson('invalid json', 'v1.0.0');


### PR DESCRIPTION
## Summary
- Branch versions were stored without the `dev-` prefix (e.g., `main` instead of `dev-main`), causing Composer's VersionParser to reject them as invalid version strings
- The UI install command also showed incorrect instructions (e.g., `composer require vendor/package:main` instead of `composer require vendor/package:dev-main`)
- Includes a data migration to fix existing branch versions in the database