### PR TITLE
fix(composer): use private cache-control for API responses

### DIFF
--- a/app/Http/Controllers/Composer/MetadataController.php
+++ b/app/Http/Controllers/Composer/MetadataController.php
@@ -49,7 +49,7 @@ class MetadataController extends Controller
                 'minified' => 'composer/2.0',
             ])
             ->setLastModified($package->updated_at)
-            ->setPublic()
+            ->setPrivate()
             ->setMaxAge(3600);
 
         $response->setEtag(md5((string) $response->getContent()));
@@ -99,7 +99,7 @@ class MetadataController extends Controller
                 'minified' => 'composer/2.0',
             ])
             ->setLastModified($package->updated_at)
-            ->setPublic()
+            ->setPrivate()
             ->setMaxAge(3600);
 
         $response->setEtag(md5((string) $response->getContent()));

--- a/app/Http/Controllers/Composer/PackageController.php
+++ b/app/Http/Controllers/Composer/PackageController.php
@@ -32,7 +32,7 @@ class PackageController extends Controller
             $response->setLastModified(new \DateTime($lastModified));
         }
 
-        $response->setPublic()
+        $response->setPrivate()
             ->setMaxAge(300);
 
         $response->setEtag(md5((string) $response->getContent()));

--- a/tests/Feature/Composer/ComposerApiTest.php
+++ b/tests/Feature/Composer/ComposerApiTest.php
@@ -210,7 +210,7 @@ it('includes caching headers', function () {
         ->assertHeader('Cache-Control')
         ->assertHeader('Last-Modified');
 
-    expect($response->headers->get('Cache-Control'))->toContain('max-age=3600', 'public');
+    expect($response->headers->get('Cache-Control'))->toContain('max-age=3600', 'private');
 });
 
 it('includes dist information when available', function () {


### PR DESCRIPTION
## Summary
- Changed `Cache-Control` from `public` to `private` on Composer API endpoints (`packages.json`, metadata, and dev metadata)
- Prevents CDNs like Cloudflare from caching authenticated responses