### PR TITLE
feat(ui): add release notes viewer and outdated version indicator

### DIFF
--- a/app/Domains/Release/Actions/FetchLatestReleasesAction.php
+++ b/app/Domains/Release/Actions/FetchLatestReleasesAction.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Domains\Release\Actions;
+
+use App\Domains\Release\Contracts\Data\ReleaseData;
+use App\Domains\Release\Contracts\Data\ReleaseInfoData;
+use Composer\Semver\Comparator;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class FetchLatestReleasesAction
+{
+    private const CACHE_KEY = 'pricore.releases';
+
+    private const COOLDOWN_KEY = 'pricore.releases:cooldown';
+
+    private const REPO = 'pricorephp/pricore';
+
+    public function handle(): ?ReleaseInfoData
+    {
+        $cached = Cache::get(self::CACHE_KEY);
+
+        if ($cached instanceof ReleaseInfoData) {
+            return $cached;
+        }
+
+        if (Cache::has(self::COOLDOWN_KEY)) {
+            return null;
+        }
+
+        $info = $this->fetch();
+
+        if ($info === null) {
+            Cache::put(self::COOLDOWN_KEY, true, now()->addMinutes(15));
+
+            return null;
+        }
+
+        Cache::put(self::CACHE_KEY, $info, now()->addDay());
+
+        return $info;
+    }
+
+    private function fetch(): ?ReleaseInfoData
+    {
+        try {
+            $response = Http::baseUrl('https://api.github.com')
+                ->withHeaders([
+                    'Accept' => 'application/vnd.github+json',
+                    'X-GitHub-Api-Version' => '2022-11-28',
+                    'User-Agent' => 'Pricore',
+                ])
+                ->timeout(10)
+                ->get('/repos/'.self::REPO.'/releases', ['per_page' => 20]);
+
+            if (! $response->successful()) {
+                Log::warning('Failed to fetch Pricore releases from GitHub', [
+                    'status' => $response->status(),
+                ]);
+
+                return null;
+            }
+
+            /** @var array<int, array<string, mixed>> $payload */
+            $payload = $response->json() ?? [];
+        } catch (\Throwable $exception) {
+            Log::warning('Exception while fetching Pricore releases from GitHub', [
+                'message' => $exception->getMessage(),
+            ]);
+
+            return null;
+        }
+
+        $releases = collect($payload)
+            ->reject(fn (array $release) => ($release['draft'] ?? false) || ($release['prerelease'] ?? false))
+            ->map(fn (array $release) => $this->mapRelease($release))
+            ->values()
+            ->all();
+
+        $currentVersion = $this->normalizeVersion(config('app.version'));
+        $latestVersion = $releases[0]->version ?? null;
+
+        $isOutdated = false;
+        if ($currentVersion !== null && $latestVersion !== null) {
+            try {
+                $isOutdated = Comparator::greaterThan($latestVersion, $currentVersion);
+            } catch (\Throwable) {
+                $isOutdated = false;
+            }
+        }
+
+        return new ReleaseInfoData(
+            currentVersion: $currentVersion,
+            latestVersion: $latestVersion,
+            isOutdated: $isOutdated,
+            releases: $releases,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $release
+     */
+    private function mapRelease(array $release): ReleaseData
+    {
+        $tagName = (string) ($release['tag_name'] ?? '');
+        $name = (string) ($release['name'] ?? $tagName);
+        $body = (string) ($release['body'] ?? '');
+
+        return new ReleaseData(
+            name: $name !== '' ? $name : $tagName,
+            tagName: $tagName,
+            version: $this->normalizeVersion($tagName) ?? $tagName,
+            htmlUrl: (string) ($release['html_url'] ?? ''),
+            publishedAt: $release['published_at'] ?? null,
+            bodyHtml: $body === '' ? '' : Str::markdown($body, [
+                'html_input' => 'strip',
+                'allow_unsafe_links' => false,
+            ]),
+        );
+    }
+
+    private function normalizeVersion(?string $version): ?string
+    {
+        if ($version === null || $version === '') {
+            return null;
+        }
+
+        return preg_replace('/^(v|release[-_]?)/i', '', $version) ?? $version;
+    }
+}

--- a/app/Domains/Release/Contracts/Data/ReleaseData.php
+++ b/app/Domains/Release/Contracts/Data/ReleaseData.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Domains\Release\Contracts\Data;
+
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+class ReleaseData extends Data
+{
+    public function __construct(
+        public string $name,
+        public string $tagName,
+        public string $version,
+        public string $htmlUrl,
+        public ?string $publishedAt,
+        public string $bodyHtml,
+    ) {}
+}

--- a/app/Domains/Release/Contracts/Data/ReleaseInfoData.php
+++ b/app/Domains/Release/Contracts/Data/ReleaseInfoData.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Domains\Release\Contracts\Data;
+
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+class ReleaseInfoData extends Data
+{
+    /**
+     * @param  array<int, ReleaseData>  $releases
+     */
+    public function __construct(
+        public ?string $currentVersion,
+        public ?string $latestVersion,
+        public bool $isOutdated,
+        public array $releases,
+    ) {}
+}

--- a/app/Domains/Release/Http/Controllers/ReleaseController.php
+++ b/app/Domains/Release/Http/Controllers/ReleaseController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Domains\Release\Http\Controllers;
+
+use App\Domains\Release\Actions\FetchLatestReleasesAction;
+use Illuminate\Http\JsonResponse;
+
+class ReleaseController
+{
+    public function __invoke(FetchLatestReleasesAction $fetchLatestReleasesAction): JsonResponse
+    {
+        return response()->json([
+            'release_info' => $fetchLatestReleasesAction->handle(),
+        ]);
+    }
+}

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -1,10 +1,12 @@
 import { NavMain } from '@/components/nav-main';
+import ReleaseNotesDialog from '@/components/release-notes-dialog';
 import {
     Sidebar,
     SidebarContent,
     SidebarFooter,
     SidebarHeader,
 } from '@/components/ui/sidebar';
+import { useReleaseInfo } from '@/hooks/use-release-info';
 import { dashboard } from '@/routes';
 import { type NavItem, type SharedData } from '@/types';
 import { Link, usePage } from '@inertiajs/react';
@@ -16,7 +18,7 @@ import {
     Settings,
     ShieldAlert,
 } from 'lucide-react';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import AppLogoIcon from './app-logo-icon';
 
 export function AppSidebar() {
@@ -24,6 +26,8 @@ export function AppSidebar() {
     const url = page.url;
     const version = page.props.version;
     const organizations = page.props.auth.organizations;
+    const { info: releaseInfo } = useReleaseInfo();
+    const [releaseNotesOpen, setReleaseNotesOpen] = useState(false);
 
     // Extract organization slug from URL
     const currentOrgSlug = useMemo(() => {
@@ -96,16 +100,24 @@ export function AppSidebar() {
             </SidebarContent>
 
             <SidebarFooter className="border-t border-sidebar-border pt-2">
-                {version && (
-                    <a
-                        href="https://github.com/pricorephp/pricore/releases"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-center text-[10.5px] text-sidebar-foreground/50 transition-colors hover:text-sidebar-foreground/70"
-                    >
-                        v{version}
-                    </a>
-                )}
+                <button
+                    type="button"
+                    onClick={() => setReleaseNotesOpen(true)}
+                    className="inline-flex items-center justify-center gap-1.5 text-[10.5px] text-sidebar-foreground/50 transition-colors hover:text-sidebar-foreground/70"
+                    title={
+                        releaseInfo?.isOutdated
+                            ? `Update available: v${releaseInfo.latestVersion}`
+                            : 'View release notes'
+                    }
+                >
+                    <span>{version ? `v${version}` : 'Releases'}</span>
+                    {releaseInfo?.isOutdated && (
+                        <span
+                            className="size-1.5 rounded-full bg-primary"
+                            aria-label="Update available"
+                        />
+                    )}
+                </button>
                 <a
                     href="https://docs.pricore.dev"
                     target="_blank"
@@ -118,6 +130,12 @@ export function AppSidebar() {
                     </span>
                 </a>
             </SidebarFooter>
+
+            <ReleaseNotesDialog
+                open={releaseNotesOpen}
+                onOpenChange={setReleaseNotesOpen}
+                info={releaseInfo}
+            />
         </Sidebar>
     );
 }

--- a/resources/js/components/release-notes-dialog.tsx
+++ b/resources/js/components/release-notes-dialog.tsx
@@ -1,0 +1,152 @@
+import { Badge } from '@/components/ui/badge';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { DateTime } from 'luxon';
+
+type ReleaseData = App.Domains.Release.Contracts.Data.ReleaseData;
+type ReleaseInfoData = Omit<
+    App.Domains.Release.Contracts.Data.ReleaseInfoData,
+    'releases'
+> & {
+    releases: ReleaseData[];
+};
+
+interface ReleaseNotesDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    info: ReleaseInfoData | null;
+}
+
+export default function ReleaseNotesDialog({
+    open,
+    onOpenChange,
+    info,
+}: ReleaseNotesDialogProps) {
+    const releases = info?.releases ?? [];
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="flex max-h-[80vh] w-full flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl">
+                <DialogHeader className="border-b border-border px-6 pt-5 pb-4">
+                    <DialogTitle>Release notes</DialogTitle>
+                    <DialogDescription>
+                        {renderStatusLine(info)}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="flex-1 overflow-y-auto px-6 py-4">
+                    {releases.length === 0 ? (
+                        <p className="text-muted-foreground">
+                            Couldn&apos;t load release notes.{' '}
+                            <a
+                                href="https://github.com/pricorephp/pricore/releases"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="underline hover:text-foreground"
+                            >
+                                View on GitHub
+                            </a>
+                            .
+                        </p>
+                    ) : (
+                        <ol className="flex flex-col gap-8">
+                            {releases.map((release) => (
+                                <ReleaseEntry
+                                    key={release.tagName}
+                                    release={release}
+                                    isCurrent={
+                                        release.version ===
+                                        info?.currentVersion
+                                    }
+                                />
+                            ))}
+                        </ol>
+                    )}
+                </div>
+
+                <div className="border-t border-border px-6 py-3 text-right">
+                    <a
+                        href="https://github.com/pricorephp/pricore/releases"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm text-muted-foreground hover:text-foreground hover:underline"
+                    >
+                        View all releases on GitHub
+                    </a>
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+function renderStatusLine(info: ReleaseInfoData | null): string {
+    if (!info) return 'Latest releases from GitHub.';
+
+    const { currentVersion, latestVersion, isOutdated } = info;
+
+    if (currentVersion && latestVersion) {
+        if (isOutdated) {
+            return `Running v${currentVersion} · Latest v${latestVersion}`;
+        }
+        return `Running v${currentVersion} · You're up to date`;
+    }
+
+    if (latestVersion) {
+        return `Latest release: v${latestVersion}`;
+    }
+
+    return 'Latest releases from GitHub.';
+}
+
+interface ReleaseEntryProps {
+    release: ReleaseData;
+    isCurrent: boolean;
+}
+
+function ReleaseEntry({ release, isCurrent }: ReleaseEntryProps) {
+    const publishedAt = release.publishedAt
+        ? DateTime.fromISO(release.publishedAt).toLocaleString(
+              DateTime.DATE_MED,
+          )
+        : null;
+
+    return (
+        <li>
+            <div className="mb-2 flex items-baseline gap-2">
+                <a
+                    href={release.htmlUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-semibold text-foreground hover:underline"
+                >
+                    {release.name}
+                </a>
+                {publishedAt && (
+                    <span className="text-xs text-muted-foreground">
+                        {publishedAt}
+                    </span>
+                )}
+                {isCurrent && (
+                    <Badge variant="success" className="ml-auto">
+                        Current
+                    </Badge>
+                )}
+            </div>
+            {release.bodyHtml ? (
+                <div
+                    className="text-muted-foreground [&_a]:text-foreground [&_a]:underline [&_blockquote]:border-l-2 [&_blockquote]:border-border [&_blockquote]:pl-3 [&_blockquote]:italic [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-foreground [&_h1]:mt-3 [&_h1]:mb-1 [&_h1]:text-base [&_h1]:font-semibold [&_h1]:text-foreground [&_h2]:mt-3 [&_h2]:mb-1 [&_h2]:text-base [&_h2]:font-semibold [&_h2]:text-foreground [&_h3]:mt-3 [&_h3]:mb-1 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:text-foreground [&_li]:mb-1 [&_ol]:my-2 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:my-2 [&_pre]:my-2 [&_pre]:overflow-x-auto [&_pre]:rounded [&_pre]:bg-muted [&_pre]:p-2 [&_pre]:text-xs [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_ul]:my-2 [&_ul]:list-disc [&_ul]:pl-5"
+                    dangerouslySetInnerHTML={{ __html: release.bodyHtml }}
+                />
+            ) : (
+                <p className="text-muted-foreground italic">
+                    No notes provided.
+                </p>
+            )}
+        </li>
+    );
+}

--- a/resources/js/hooks/use-release-info.ts
+++ b/resources/js/hooks/use-release-info.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+
+type ReleaseData = App.Domains.Release.Contracts.Data.ReleaseData;
+type ReleaseInfoData = Omit<
+    App.Domains.Release.Contracts.Data.ReleaseInfoData,
+    'releases'
+> & {
+    releases: ReleaseData[];
+};
+
+export function useReleaseInfo(): {
+    info: ReleaseInfoData | null;
+    loading: boolean;
+} {
+    const [info, setInfo] = useState<ReleaseInfoData | null>(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        fetch('/releases', {
+            headers: { Accept: 'application/json' },
+            credentials: 'same-origin',
+        })
+            .then((response) => (response.ok ? response.json() : null))
+            .then((data) => {
+                if (cancelled) return;
+                setInfo((data?.release_info as ReleaseInfoData | null) ?? null);
+            })
+            .catch(() => {})
+            .finally(() => {
+                if (!cancelled) setLoading(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    return { info, loading };
+}

--- a/resources/types/generated.d.ts
+++ b/resources/types/generated.d.ts
@@ -196,6 +196,22 @@ version: string;
 dailyDownloads: Array<App.Domains.Organization.Contracts.Data.DailyDownloadData>;
 };
 }
+declare namespace App.Domains.Release.Contracts.Data {
+export type ReleaseData = {
+name: string;
+tagName: string;
+version: string;
+htmlUrl: string;
+publishedAt: string | null;
+bodyHtml: string;
+};
+export type ReleaseInfoData = {
+currentVersion: string | null;
+latestVersion: string | null;
+isOutdated: boolean;
+releases: Array<any>;
+};
+}
 declare namespace App.Domains.Repository.Contracts.Data {
 export type RepositoryData = {
 uuid: string;

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Domains\Organization\Http\Controllers\SettingsController;
 use App\Domains\Organization\Http\Controllers\SshKeyController;
 use App\Domains\Package\Http\Controllers\PackageController;
 use App\Domains\Package\Http\Controllers\PackageVersionController;
+use App\Domains\Release\Http\Controllers\ReleaseController;
 use App\Domains\Repository\Http\Controllers\Api\RepositorySuggestionController;
 use App\Domains\Repository\Http\Controllers\RepositoryController;
 use App\Domains\Repository\Http\Controllers\SyncRepositoryController;
@@ -40,6 +41,8 @@ Route::post('invitations/{token}/accept', [AcceptInvitationController::class, 'a
 
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/', DashboardController::class)->name('dashboard');
+
+    Route::get('releases', ReleaseController::class)->name('releases.index');
 
     // Organizations
     Route::get('organizations', [OrganizationController::class, 'index'])->name('organizations.index');

--- a/tests/Feature/Domains/Release/FetchLatestReleasesActionTest.php
+++ b/tests/Feature/Domains/Release/FetchLatestReleasesActionTest.php
@@ -1,0 +1,177 @@
+<?php
+
+use App\Domains\Release\Actions\FetchLatestReleasesAction;
+use App\Domains\Release\Contracts\Data\ReleaseInfoData;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    Cache::flush();
+    $this->fetchLatestReleasesAction = app(FetchLatestReleasesAction::class);
+});
+
+function fakeReleasesResponse(array $releases): void
+{
+    Http::fake([
+        'api.github.com/repos/pricorephp/pricore/releases*' => Http::response($releases, 200),
+    ]);
+}
+
+it('fetches releases, caches them, and detects an outdated version', function () {
+    config()->set('app.version', '1.0.0');
+
+    fakeReleasesResponse([
+        [
+            'name' => 'v1.2.0',
+            'tag_name' => 'v1.2.0',
+            'html_url' => 'https://github.com/pricorephp/pricore/releases/tag/v1.2.0',
+            'published_at' => '2026-04-01T12:00:00Z',
+            'body' => "## Features\n\n- Adds release notes viewer",
+            'draft' => false,
+            'prerelease' => false,
+        ],
+        [
+            'name' => 'v1.0.0',
+            'tag_name' => 'v1.0.0',
+            'html_url' => 'https://github.com/pricorephp/pricore/releases/tag/v1.0.0',
+            'published_at' => '2026-03-01T12:00:00Z',
+            'body' => 'Initial release',
+            'draft' => false,
+            'prerelease' => false,
+        ],
+    ]);
+
+    $info = $this->fetchLatestReleasesAction->handle();
+
+    expect($info)->toBeInstanceOf(ReleaseInfoData::class);
+    expect($info->currentVersion)->toBe('1.0.0');
+    expect($info->latestVersion)->toBe('1.2.0');
+    expect($info->isOutdated)->toBeTrue();
+    expect($info->releases)->toHaveCount(2);
+    expect($info->releases[0]->bodyHtml)->toContain('<h2>Features</h2>');
+
+    // Second call must come from cache, not GitHub.
+    $this->fetchLatestReleasesAction->handle();
+    Http::assertSentCount(1);
+});
+
+it('reports not outdated when running the latest version', function () {
+    config()->set('app.version', '1.2.0');
+
+    fakeReleasesResponse([
+        [
+            'name' => 'v1.2.0',
+            'tag_name' => 'v1.2.0',
+            'html_url' => 'https://github.com/pricorephp/pricore/releases/tag/v1.2.0',
+            'published_at' => '2026-04-01T12:00:00Z',
+            'body' => 'Latest',
+            'draft' => false,
+            'prerelease' => false,
+        ],
+    ]);
+
+    $info = $this->fetchLatestReleasesAction->handle();
+
+    expect($info->isOutdated)->toBeFalse();
+    expect($info->currentVersion)->toBe('1.2.0');
+    expect($info->latestVersion)->toBe('1.2.0');
+});
+
+it('filters out drafts and prereleases', function () {
+    config()->set('app.version', '1.0.0');
+
+    fakeReleasesResponse([
+        [
+            'name' => 'v1.3.0-beta.1',
+            'tag_name' => 'v1.3.0-beta.1',
+            'html_url' => 'https://github.com/pricorephp/pricore/releases/tag/v1.3.0-beta.1',
+            'published_at' => '2026-04-05T12:00:00Z',
+            'body' => 'Beta',
+            'draft' => false,
+            'prerelease' => true,
+        ],
+        [
+            'name' => 'v1.2.0',
+            'tag_name' => 'v1.2.0',
+            'html_url' => 'https://github.com/pricorephp/pricore/releases/tag/v1.2.0',
+            'published_at' => '2026-04-01T12:00:00Z',
+            'body' => 'Stable',
+            'draft' => false,
+            'prerelease' => false,
+        ],
+        [
+            'name' => 'draft',
+            'tag_name' => 'v1.4.0',
+            'html_url' => 'https://github.com/pricorephp/pricore/releases/tag/v1.4.0',
+            'published_at' => null,
+            'body' => 'Draft',
+            'draft' => true,
+            'prerelease' => false,
+        ],
+    ]);
+
+    $info = $this->fetchLatestReleasesAction->handle();
+
+    expect($info->releases)->toHaveCount(1);
+    expect($info->latestVersion)->toBe('1.2.0');
+});
+
+it('returns null and does not throw when GitHub fails', function () {
+    config()->set('app.version', '1.0.0');
+
+    Http::fake([
+        'api.github.com/repos/pricorephp/pricore/releases*' => Http::response([], 503),
+    ]);
+
+    $info = $this->fetchLatestReleasesAction->handle();
+
+    expect($info)->toBeNull();
+});
+
+it('honors the cooldown after a failed fetch', function () {
+    config()->set('app.version', '1.0.0');
+
+    Http::fake([
+        'api.github.com/repos/pricorephp/pricore/releases*' => Http::response([], 503),
+    ]);
+
+    $this->fetchLatestReleasesAction->handle();
+    $this->fetchLatestReleasesAction->handle();
+
+    Http::assertSentCount(1);
+});
+
+it('returns release info with null current version when APP_VERSION is unset', function () {
+    config()->set('app.version', null);
+
+    fakeReleasesResponse([
+        [
+            'name' => 'v1.2.0',
+            'tag_name' => 'v1.2.0',
+            'html_url' => 'https://github.com/pricorephp/pricore/releases/tag/v1.2.0',
+            'published_at' => '2026-04-01T12:00:00Z',
+            'body' => 'Latest',
+            'draft' => false,
+            'prerelease' => false,
+        ],
+    ]);
+
+    $info = $this->fetchLatestReleasesAction->handle();
+
+    expect($info->currentVersion)->toBeNull();
+    expect($info->isOutdated)->toBeFalse();
+});
+
+it('sends the proper headers to GitHub', function () {
+    config()->set('app.version', '1.0.0');
+    fakeReleasesResponse([]);
+
+    $this->fetchLatestReleasesAction->handle();
+
+    Http::assertSent(function (Request $request) {
+        return str_contains($request->url(), 'api.github.com/repos/pricorephp/pricore/releases')
+            && $request->hasHeader('Accept', 'application/vnd.github+json')
+            && $request->hasHeader('User-Agent', 'Pricore');
+    });
+});


### PR DESCRIPTION
- Sidebar version footer becomes a button that opens a release notes modal; small dot appears next to it when a newer release is available on GitHub.
- Releases are fetched lazily by end-user traffic and cached server-side for 24h (with a 15-min cooldown on failure), so there's no scheduler dependency.