### PR TITLE
fix(docker): propagate APP_URL to horizon, scheduler, and reverb services

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -57,6 +57,7 @@ services:
       - APP_ENV=${APP_ENV:-production}
       - APP_DEBUG=${APP_DEBUG:-false}
       - APP_KEY=${APP_KEY:-}
+      - APP_URL=${APP_URL:-http://localhost:8000}
       - DB_CONNECTION=${DB_CONNECTION:-sqlite}
       - DB_DATABASE=${DB_DATABASE:-/app/database/database.sqlite}
       - REDIS_HOST=redis
@@ -96,6 +97,7 @@ services:
       - APP_ENV=${APP_ENV:-production}
       - APP_DEBUG=${APP_DEBUG:-false}
       - APP_KEY=${APP_KEY:-}
+      - APP_URL=${APP_URL:-http://localhost:8000}
       - DB_CONNECTION=${DB_CONNECTION:-sqlite}
       - DB_DATABASE=${DB_DATABASE:-/app/database/database.sqlite}
       - REDIS_HOST=redis
@@ -124,6 +126,7 @@ services:
       - APP_ENV=${APP_ENV:-production}
       - APP_DEBUG=${APP_DEBUG:-false}
       - APP_KEY=${APP_KEY:-}
+      - APP_URL=${APP_URL:-http://localhost:8000}
       - DB_CONNECTION=${DB_CONNECTION:-sqlite}
       - DB_DATABASE=${DB_DATABASE:-/app/database/database.sqlite}
       - REDIS_HOST=redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       - APP_ENV=${APP_ENV:-production}
       - APP_DEBUG=${APP_DEBUG:-false}
       - APP_KEY=${APP_KEY:-}
+      - APP_URL=${APP_URL:-http://localhost:8000}
       - DB_CONNECTION=${DB_CONNECTION:-sqlite}
       - DB_DATABASE=${DB_DATABASE:-/app/database/database.sqlite}
       - REDIS_HOST=redis
@@ -90,6 +91,7 @@ services:
       - APP_ENV=${APP_ENV:-production}
       - APP_DEBUG=${APP_DEBUG:-false}
       - APP_KEY=${APP_KEY:-}
+      - APP_URL=${APP_URL:-http://localhost:8000}
       - DB_CONNECTION=${DB_CONNECTION:-sqlite}
       - DB_DATABASE=${DB_DATABASE:-/app/database/database.sqlite}
       - REDIS_HOST=redis
@@ -116,6 +118,7 @@ services:
       - APP_ENV=${APP_ENV:-production}
       - APP_DEBUG=${APP_DEBUG:-false}
       - APP_KEY=${APP_KEY:-}
+      - APP_URL=${APP_URL:-http://localhost:8000}
       - DB_CONNECTION=${DB_CONNECTION:-sqlite}
       - DB_DATABASE=${DB_DATABASE:-/app/database/database.sqlite}
       - REDIS_HOST=redis


### PR DESCRIPTION
Fixes #104.

Only the `app` service received `APP_URL`, so queued jobs running in Horizon (and code in the scheduler / reverb containers) fell back to Laravel's default `http://localhost`, which got persisted into `package_versions.dist_url` and served to Composer. Adding `APP_URL` to every Laravel-running service in both compose files fixes new syncs; existing rows with the bad host will need a resync to be rewritten.