### PR TITLE
fix(sync): use git commit date for package version released_at

### DIFF
--- a/app/Domains/Repository/Actions/SyncRefAction.php
+++ b/app/Domains/Repository/Actions/SyncRefAction.php
@@ -8,6 +8,7 @@ use App\Domains\Repository\Contracts\Interfaces\GitProviderInterface;
 use App\Models\Package;
 use App\Models\PackageVersion;
 use App\Models\Repository;
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
@@ -57,7 +58,9 @@ class SyncRefAction
             }
         }
 
-        $result = DB::transaction(function () use ($metadata, $ref, $package, $repository, $provider): array {
+        $releasedAt = $this->resolveReleasedAt($provider, $ref, $metadata);
+
+        $result = DB::transaction(function () use ($metadata, $ref, $package, $repository, $provider, $releasedAt): array {
             if (! $package) {
                 $package = $this->findOrCreatePackage->handle($repository, $metadata->name);
             }
@@ -77,6 +80,7 @@ class SyncRefAction
                     'source_url' => $sourceUrl,
                     'source_reference' => $ref->commit,
                     'source_tag' => $ref->name,
+                    'released_at' => $releasedAt,
                 ]);
 
                 return ['status' => 'updated', 'version' => $version, 'package' => $package];
@@ -90,7 +94,7 @@ class SyncRefAction
                 'source_url' => $sourceUrl,
                 'source_reference' => $ref->commit,
                 'source_tag' => $ref->name,
-                'released_at' => now(),
+                'released_at' => $releasedAt,
             ]);
 
             return ['status' => 'added', 'version' => $version, 'package' => $package];
@@ -101,6 +105,28 @@ class SyncRefAction
         }
 
         return $result['status'];
+    }
+
+    protected function resolveReleasedAt(
+        GitProviderInterface $provider,
+        RefData $ref,
+        ComposerMetadataData $metadata,
+    ): CarbonImmutable {
+        $commitDate = $provider->getCommitDate($ref->commit);
+
+        if ($commitDate) {
+            return $commitDate;
+        }
+
+        if (isset($metadata->composerJson['time']) && is_string($metadata->composerJson['time'])) {
+            try {
+                return CarbonImmutable::parse($metadata->composerJson['time']);
+            } catch (\Exception) {
+                // fall through to now()
+            }
+        }
+
+        return CarbonImmutable::now();
     }
 
     protected function createDistForVersion(

--- a/app/Domains/Repository/Contracts/Interfaces/GitProviderInterface.php
+++ b/app/Domains/Repository/Contracts/Interfaces/GitProviderInterface.php
@@ -2,6 +2,8 @@
 
 namespace App\Domains\Repository\Contracts\Interfaces;
 
+use Carbon\CarbonImmutable;
+
 interface GitProviderInterface
 {
     /**
@@ -15,6 +17,8 @@ interface GitProviderInterface
     public function getBranches(): array;
 
     public function getFileContent(string $ref, string $path): ?string;
+
+    public function getCommitDate(string $ref): ?CarbonImmutable;
 
     public function validateCredentials(): bool;
 

--- a/app/Domains/Repository/Services/GitProviders/BitbucketProvider.php
+++ b/app/Domains/Repository/Services/GitProviders/BitbucketProvider.php
@@ -4,6 +4,7 @@ namespace App\Domains\Repository\Services\GitProviders;
 
 use App\Domains\Repository\Contracts\Data\RepositorySuggestionData;
 use App\Domains\Repository\Exceptions\GitProviderException;
+use Carbon\CarbonImmutable;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
@@ -180,6 +181,35 @@ class BitbucketProvider extends AbstractGitProvider
                 "Failed to fetch file content: {$e->getMessage()}",
                 previous: $e
             );
+        }
+    }
+
+    public function getCommitDate(string $ref): ?CarbonImmutable
+    {
+        try {
+            $response = $this->http->get("/repositories/{$this->repositoryIdentifier}/commit/{$ref}");
+
+            if ($response->status() === 404) {
+                return null;
+            }
+
+            if ($response->failed()) {
+                throw new GitProviderException(
+                    "Failed to fetch commit from Bitbucket: {$response->body()}"
+                );
+            }
+
+            $date = $response->json('date');
+
+            return $date ? CarbonImmutable::parse($date) : null;
+        } catch (\Exception $e) {
+            Log::warning('Bitbucket API error fetching commit date', [
+                'repository' => $this->repositoryIdentifier,
+                'ref' => $ref,
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
         }
     }
 

--- a/app/Domains/Repository/Services/GitProviders/CachedGitProvider.php
+++ b/app/Domains/Repository/Services/GitProviders/CachedGitProvider.php
@@ -4,6 +4,7 @@ namespace App\Domains\Repository\Services\GitProviders;
 
 use App\Domains\Repository\Contracts\Interfaces\GitProviderInterface;
 use App\Domains\Repository\Exceptions\GitProviderException;
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Process;
 
 class CachedGitProvider implements GitProviderInterface
@@ -34,6 +35,29 @@ class CachedGitProvider implements GitProviderInterface
         }
 
         return $result->output();
+    }
+
+    public function getCommitDate(string $ref): ?CarbonImmutable
+    {
+        $result = Process::path($this->clonePath)
+            ->env(['GIT_TERMINAL_PROMPT' => '0'])
+            ->run(['git', 'show', '-s', '--format=%cI', $ref]);
+
+        if ($result->failed()) {
+            return null;
+        }
+
+        $date = trim($result->output());
+
+        if ($date === '') {
+            return null;
+        }
+
+        try {
+            return CarbonImmutable::parse($date);
+        } catch (\Exception) {
+            return null;
+        }
     }
 
     public function validateCredentials(): bool

--- a/app/Domains/Repository/Services/GitProviders/GenericGitProvider.php
+++ b/app/Domains/Repository/Services/GitProviders/GenericGitProvider.php
@@ -3,6 +3,7 @@
 namespace App\Domains\Repository\Services\GitProviders;
 
 use App\Domains\Repository\Exceptions\GitProviderException;
+use Carbon\CarbonImmutable;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
@@ -72,6 +73,13 @@ class GenericGitProvider extends AbstractGitProvider
         } finally {
             File::deleteDirectory($tempDir);
         }
+    }
+
+    public function getCommitDate(string $ref): ?CarbonImmutable
+    {
+        // Generic Git only has ls-remote without a clone, so commit dates are not
+        // available here. The SyncRefAction path runs against CachedGitProvider.
+        return null;
     }
 
     public function validateCredentials(): bool

--- a/app/Domains/Repository/Services/GitProviders/GitHubProvider.php
+++ b/app/Domains/Repository/Services/GitProviders/GitHubProvider.php
@@ -4,6 +4,7 @@ namespace App\Domains\Repository\Services\GitProviders;
 
 use App\Domains\Repository\Contracts\Data\RepositorySuggestionData;
 use App\Domains\Repository\Exceptions\GitProviderException;
+use Carbon\CarbonImmutable;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
@@ -223,6 +224,35 @@ class GitHubProvider extends AbstractGitProvider
                 "Failed to fetch file content: {$e->getMessage()}",
                 previous: $e
             );
+        }
+    }
+
+    public function getCommitDate(string $ref): ?CarbonImmutable
+    {
+        try {
+            $response = $this->http->get("/repos/{$this->repositoryIdentifier}/commits/{$ref}");
+
+            if ($response->status() === 404) {
+                return null;
+            }
+
+            if ($response->failed()) {
+                throw new GitProviderException(
+                    "Failed to fetch commit from GitHub: {$response->body()}"
+                );
+            }
+
+            $date = $response->json('commit.committer.date') ?? $response->json('commit.author.date');
+
+            return $date ? CarbonImmutable::parse($date) : null;
+        } catch (\Exception $e) {
+            Log::warning('GitHub API error fetching commit date', [
+                'repository' => $this->repositoryIdentifier,
+                'ref' => $ref,
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
         }
     }
 

--- a/app/Domains/Repository/Services/GitProviders/GitLabProvider.php
+++ b/app/Domains/Repository/Services/GitProviders/GitLabProvider.php
@@ -4,6 +4,7 @@ namespace App\Domains\Repository\Services\GitProviders;
 
 use App\Domains\Repository\Contracts\Data\RepositorySuggestionData;
 use App\Domains\Repository\Exceptions\GitProviderException;
+use Carbon\CarbonImmutable;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
@@ -202,6 +203,36 @@ class GitLabProvider extends AbstractGitProvider
                 "Failed to fetch file content: {$e->getMessage()}",
                 previous: $e
             );
+        }
+    }
+
+    public function getCommitDate(string $ref): ?CarbonImmutable
+    {
+        try {
+            $projectPath = $this->getEncodedProjectPath();
+            $response = $this->http->get("/projects/{$projectPath}/repository/commits/{$ref}");
+
+            if ($response->status() === 404) {
+                return null;
+            }
+
+            if ($response->failed()) {
+                throw new GitProviderException(
+                    "Failed to fetch commit from GitLab: {$response->body()}"
+                );
+            }
+
+            $date = $response->json('committed_date') ?? $response->json('authored_date');
+
+            return $date ? CarbonImmutable::parse($date) : null;
+        } catch (\Exception $e) {
+            Log::warning('GitLab API error fetching commit date', [
+                'repository' => $this->repositoryIdentifier,
+                'ref' => $ref,
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
         }
     }
 

--- a/tests/Feature/Domains/Repository/SyncRefActionTest.php
+++ b/tests/Feature/Domains/Repository/SyncRefActionTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use App\Domains\Repository\Actions\SyncRefAction;
+use App\Domains\Repository\Contracts\Data\RefData;
+use App\Domains\Repository\Contracts\Interfaces\GitProviderInterface;
+use App\Models\Organization;
+use App\Models\PackageVersion;
+use App\Models\Repository;
+use Carbon\CarbonImmutable;
+
+function mockProviderForRefSync(array $composerJson, ?CarbonImmutable $commitDate): GitProviderInterface
+{
+    $mock = Mockery::mock(GitProviderInterface::class);
+    $mock->shouldReceive('getFileContent')
+        ->with(Mockery::any(), 'composer.json')
+        ->andReturn(json_encode($composerJson));
+    $mock->shouldReceive('getCommitDate')->andReturn($commitDate);
+    $mock->shouldReceive('getRepositoryUrl')->andReturn('git@github.com:vendor/repo.git');
+
+    return $mock;
+}
+
+it('uses the commit date from the provider as released_at', function () {
+    $organization = Organization::factory()->create();
+    $repository = Repository::factory()->forOrganization($organization)->create();
+
+    $commitDate = CarbonImmutable::parse('2025-12-01T10:30:00Z');
+    $provider = mockProviderForRefSync([
+        'name' => 'vendor/package',
+        'type' => 'library',
+    ], $commitDate);
+
+    $result = app(SyncRefAction::class)->handle(
+        $provider,
+        $repository,
+        new RefData(name: 'v1.0.0', commit: 'abc123')
+    );
+
+    expect($result)->toBe('added');
+    expect(PackageVersion::first()->released_at->equalTo($commitDate))->toBeTrue();
+});
+
+it('falls back to composer.json time when the provider returns no commit date', function () {
+    $organization = Organization::factory()->create();
+    $repository = Repository::factory()->forOrganization($organization)->create();
+
+    $provider = mockProviderForRefSync([
+        'name' => 'vendor/package',
+        'type' => 'library',
+        'time' => '2025-11-15T08:00:00Z',
+    ], null);
+
+    app(SyncRefAction::class)->handle(
+        $provider,
+        $repository,
+        new RefData(name: 'v1.0.0', commit: 'abc123')
+    );
+
+    $expected = CarbonImmutable::parse('2025-11-15T08:00:00Z');
+    expect(PackageVersion::first()->released_at->equalTo($expected))->toBeTrue();
+});
+
+it('falls back to now() when neither commit date nor composer.json time is available', function () {
+    $organization = Organization::factory()->create();
+    $repository = Repository::factory()->forOrganization($organization)->create();
+
+    $provider = mockProviderForRefSync([
+        'name' => 'vendor/package',
+        'type' => 'library',
+    ], null);
+
+    CarbonImmutable::setTestNow('2026-04-23T12:00:00Z');
+
+    app(SyncRefAction::class)->handle(
+        $provider,
+        $repository,
+        new RefData(name: 'v1.0.0', commit: 'abc123')
+    );
+
+    $version = PackageVersion::first();
+    expect($version->released_at->equalTo(CarbonImmutable::parse('2026-04-23T12:00:00Z')))->toBeTrue();
+
+    CarbonImmutable::setTestNow();
+});
+
+it('refreshes released_at when an existing version is updated with a new commit SHA', function () {
+    $organization = Organization::factory()->create();
+    $repository = Repository::factory()->forOrganization($organization)->create();
+
+    $firstDate = CarbonImmutable::parse('2025-10-01T09:00:00Z');
+    $provider = mockProviderForRefSync([
+        'name' => 'vendor/package',
+        'type' => 'library',
+    ], $firstDate);
+
+    app(SyncRefAction::class)->handle(
+        $provider,
+        $repository,
+        new RefData(name: 'v1.0.0', commit: 'first-sha')
+    );
+
+    $secondDate = CarbonImmutable::parse('2025-12-20T14:30:00Z');
+    $updatedProvider = mockProviderForRefSync([
+        'name' => 'vendor/package',
+        'type' => 'library',
+    ], $secondDate);
+
+    $result = app(SyncRefAction::class)->handle(
+        $updatedProvider,
+        $repository,
+        new RefData(name: 'v1.0.0', commit: 'second-sha')
+    );
+
+    expect($result)->toBe('updated');
+    expect(PackageVersion::count())->toBe(1);
+    expect(PackageVersion::first()->released_at->equalTo($secondDate))->toBeTrue();
+});


### PR DESCRIPTION
- `SyncRefAction` was hardcoding `released_at = now()`, so freshly synced versions looked just-released even when the tag was weeks old.
- Now resolves to: provider commit date → `composer.json.time` → `now()`. New `getCommitDate()` on `GitProviderInterface` covers GitHub, GitLab, Bitbucket, and the cached git clone; `GenericGitProvider` returns null.