### PR TITLE
fix(bitbucket): preserve cursor query string when paginating

### DIFF
--- a/app/Domains/Repository/Services/GitProviders/BitbucketProvider.php
+++ b/app/Domains/Repository/Services/GitProviders/BitbucketProvider.php
@@ -69,7 +69,9 @@ class BitbucketProvider extends AbstractGitProvider
             $params = ['pagelen' => 100];
 
             do {
-                $response = $this->http->get($url, $params);
+                $response = $params === []
+                    ? $this->http->get($url)
+                    : $this->http->get($url, $params);
 
                 if ($response->failed()) {
                     throw new GitProviderException(
@@ -115,7 +117,9 @@ class BitbucketProvider extends AbstractGitProvider
             $params = ['pagelen' => 100];
 
             do {
-                $response = $this->http->get($url, $params);
+                $response = $params === []
+                    ? $this->http->get($url)
+                    : $this->http->get($url, $params);
 
                 if ($response->failed()) {
                     throw new GitProviderException(
@@ -313,7 +317,9 @@ class BitbucketProvider extends AbstractGitProvider
             $params = ['pagelen' => 100];
 
             do {
-                $response = $this->http->get($url, $params);
+                $response = $params === []
+                    ? $this->http->get($url)
+                    : $this->http->get($url, $params);
                 $this->throwIfResponseUnauthorized($response);
 
                 if ($response->failed()) {
@@ -358,7 +364,9 @@ class BitbucketProvider extends AbstractGitProvider
             $params = $owner ? ['pagelen' => 100] : ['pagelen' => 100, 'role' => 'member'];
 
             do {
-                $response = $this->http->get($url, $params);
+                $response = $params === []
+                    ? $this->http->get($url)
+                    : $this->http->get($url, $params);
                 $this->throwIfResponseUnauthorized($response);
 
                 if ($response->failed()) {

--- a/tests/Feature/Domains/Repository/BitbucketProviderTest.php
+++ b/tests/Feature/Domains/Repository/BitbucketProviderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use App\Domains\Repository\Services\GitProviders\BitbucketProvider;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
+it('paginates through all workspace repositories without dropping the next-page query', function () {
+    $page1 = [
+        'values' => array_map(fn (int $i) => [
+            'slug' => "repo-{$i}",
+            'full_name' => "acme/repo-{$i}",
+            'is_private' => true,
+            'description' => null,
+        ], range(1, 100)),
+        'next' => 'https://api.bitbucket.org/2.0/repositories/acme?page=2&pagelen=100',
+    ];
+
+    $page2 = [
+        'values' => array_map(fn (int $i) => [
+            'slug' => "repo-{$i}",
+            'full_name' => "acme/repo-{$i}",
+            'is_private' => true,
+            'description' => null,
+        ], range(101, 150)),
+    ];
+
+    Http::fake([
+        'api.bitbucket.org/2.0/repositories/acme?page=2*' => Http::response($page2, 200),
+        'api.bitbucket.org/2.0/repositories/acme*' => Http::response($page1, 200),
+    ]);
+
+    $bitbucketProvider = new BitbucketProvider('', [
+        'email' => 'user@example.com',
+        'api_token' => 'token',
+    ]);
+
+    $repositories = $bitbucketProvider->getRepositories('acme');
+
+    expect($repositories)->toHaveCount(150);
+    expect($repositories[0]->fullName)->toBe('acme/repo-1');
+    expect($repositories[149]->fullName)->toBe('acme/repo-150');
+
+    Http::assertSentCount(2);
+    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'page=2')
+        && str_contains($request->url(), 'pagelen=100'));
+});


### PR DESCRIPTION
- `BitbucketProvider` paginates via the `next` cursor URL, but reset `$params` to `[]` after the first page. Laravel forwarded that as `['query' => []]`, which Guzzle's `http_build_query` converts to `""` — replacing the URL's query string and stripping the `?page=2&pagelen=100` from the cursor. Each subsequent call re-fetched page 1, whose response keeps pointing at page 2, looping until PHP's 30s execution limit killed the curl handle.
- Fix: skip the `query` option entirely on iterations with no params; applied to `getTags`, `getBranches`, `getOwners`, and `getRepositories`. Added a regression test covering the `next` cursor across two pages.

Refs #87.