### PR TITLE
fix(bitbucket): repair workspace listing post-CHANGE-2770

### DIFF
--- a/app/Domains/Repository/Services/GitProviders/BitbucketProvider.php
+++ b/app/Domains/Repository/Services/GitProviders/BitbucketProvider.php
@@ -69,7 +69,9 @@ class BitbucketProvider extends AbstractGitProvider
             $params = ['pagelen' => 100];
 
             do {
-                $response = $this->http->get($url, $params);
+                $response = $params === []
+                    ? $this->http->get($url)
+                    : $this->http->get($url, $params);
 
                 if ($response->failed()) {
                     throw new GitProviderException(
@@ -115,7 +117,9 @@ class BitbucketProvider extends AbstractGitProvider
             $params = ['pagelen' => 100];
 
             do {
-                $response = $this->http->get($url, $params);
+                $response = $params === []
+                    ? $this->http->get($url)
+                    : $this->http->get($url, $params);
 
                 if ($response->failed()) {
                     throw new GitProviderException(
@@ -313,7 +317,9 @@ class BitbucketProvider extends AbstractGitProvider
             $params = ['pagelen' => 100];
 
             do {
-                $response = $this->http->get($url, $params);
+                $response = $params === []
+                    ? $this->http->get($url)
+                    : $this->http->get($url, $params);
                 $this->throwIfResponseUnauthorized($response);
 
                 if ($response->failed()) {
@@ -358,7 +364,9 @@ class BitbucketProvider extends AbstractGitProvider
             $params = $owner ? ['pagelen' => 100] : ['pagelen' => 100, 'role' => 'member'];
 
             do {
-                $response = $this->http->get($url, $params);
+                $response = $params === []
+                    ? $this->http->get($url)
+                    : $this->http->get($url, $params);
                 $this->throwIfResponseUnauthorized($response);
 
                 if ($response->failed()) {

--- a/app/Domains/Repository/Services/GitProviders/BitbucketProvider.php
+++ b/app/Domains/Repository/Services/GitProviders/BitbucketProvider.php
@@ -299,58 +299,17 @@ class BitbucketProvider extends AbstractGitProvider
     }
 
     /**
+     * Bitbucket Cloud sunset its cross-workspace enumeration APIs in
+     * CHANGE-2770 (2026-04-14): /workspaces, /repositories?role=member, and
+     * related endpoints all return a deprecation error. There is no
+     * replacement for listing the workspaces an authenticated user belongs to,
+     * so the UI must collect the workspace slug from the user instead.
+     *
      * @return array<int, string>
      */
     public function getOwners(): array
     {
-        try {
-            $owners = [];
-
-            $userResponse = $this->http->get('/user');
-            $this->throwIfResponseUnauthorized($userResponse);
-
-            if ($userResponse->successful()) {
-                $owners[] = $userResponse->json('username');
-            }
-
-            $url = '/workspaces';
-            $params = ['pagelen' => 100];
-
-            do {
-                $response = $params === []
-                    ? $this->http->get($url)
-                    : $this->http->get($url, $params);
-                $this->throwIfResponseUnauthorized($response);
-
-                if ($response->failed()) {
-                    break;
-                }
-
-                $data = $response->json();
-
-                foreach ($data['values'] ?? [] as $workspace) {
-                    $slug = $workspace['slug'];
-                    if (! in_array($slug, $owners)) {
-                        $owners[] = $slug;
-                    }
-                }
-
-                $url = $this->extractNextPath($data['next'] ?? null);
-                $params = [];
-            } while ($url !== null);
-
-            return $owners;
-        } catch (\Exception $e) {
-
-            Log::error('Bitbucket API error fetching owners', [
-                'error' => $e->getMessage(),
-            ]);
-
-            throw new GitProviderException(
-                "Failed to fetch owners: {$e->getMessage()}",
-                previous: $e
-            );
-        }
+        return [];
     }
 
     /**
@@ -358,10 +317,16 @@ class BitbucketProvider extends AbstractGitProvider
      */
     public function getRepositories(?string $owner = null): array
     {
+        if ($owner === null || $owner === '') {
+            throw new GitProviderException(
+                'Bitbucket requires a workspace to list repositories. Cross-workspace listing was sunset by Atlassian on 2026-04-14.'
+            );
+        }
+
         try {
             $repositories = [];
-            $url = $owner ? "/repositories/{$owner}" : '/repositories';
-            $params = $owner ? ['pagelen' => 100] : ['pagelen' => 100, 'role' => 'member'];
+            $url = "/repositories/{$owner}";
+            $params = ['pagelen' => 100];
 
             do {
                 $response = $params === []
@@ -387,7 +352,6 @@ class BitbucketProvider extends AbstractGitProvider
 
             return $repositories;
         } catch (\Exception $e) {
-
             Log::error('Bitbucket API error fetching repositories', [
                 'error' => $e->getMessage(),
             ]);

--- a/resources/js/components/add-repository-dialog.tsx
+++ b/resources/js/components/add-repository-dialog.tsx
@@ -66,6 +66,7 @@ export default function AddRepositoryDialog({
     const [provider, setProvider] = useState<string>(defaultProvider);
     const [owners, setOwners] = useState<string[]>([]);
     const [selectedOwner, setSelectedOwner] = useState<string>('');
+    const [workspaceInput, setWorkspaceInput] = useState<string>('');
     const [loadingOwners, setLoadingOwners] = useState(false);
     const [repositories, setRepositories] = useState<RepositorySuggestion[]>(
         [],
@@ -75,6 +76,11 @@ export default function AddRepositoryDialog({
     const [repoIdentifier, setRepoIdentifier] = useState<string>('');
     const [searchQuery, setSearchQuery] = useState<string>('');
     const repoListContainerRef = useRef<HTMLDivElement>(null);
+
+    // Bitbucket sunset its workspace enumeration API in CHANGE-2770, so the
+    // user has to type their workspace slug instead of picking from a list.
+    const isManualOwnerEntry = provider === 'bitbucket';
+    const workspaceStorageKey = `pricore.bitbucket.workspace.${organizationSlug}`;
 
     const handleClose = (): void => {
         onClose();
@@ -88,6 +94,7 @@ export default function AddRepositoryDialog({
         setProvider(defaultProvider);
         setOwners([]);
         setSelectedOwner('');
+        setWorkspaceInput('');
         setLoadingOwners(false);
         setRepositories([]);
         setLoadingRepos(false);
@@ -99,6 +106,19 @@ export default function AddRepositoryDialog({
     // Fetch owners when provider changes
     useEffect(() => {
         if (!isOpen || provider === 'git') {
+            return;
+        }
+
+        if (isManualOwnerEntry) {
+            const remembered =
+                typeof window !== 'undefined'
+                    ? window.localStorage.getItem(workspaceStorageKey) ?? ''
+                    : '';
+            setOwners([]);
+            setSelectedOwner(remembered);
+            setWorkspaceInput(remembered);
+            setLoadingOwners(false);
+            setRepositories([]);
             return;
         }
 
@@ -139,7 +159,13 @@ export default function AddRepositoryDialog({
         fetchOwners();
 
         return () => controller.abort();
-    }, [provider, organizationSlug, isOpen]);
+    }, [
+        provider,
+        organizationSlug,
+        isOpen,
+        isManualOwnerEntry,
+        workspaceStorageKey,
+    ]);
 
     // Fetch repositories when owner is selected
     useEffect(() => {
@@ -164,7 +190,18 @@ export default function AddRepositoryDialog({
 
                 if (response.ok) {
                     const data = await response.json();
-                    setRepositories(data.repositories || []);
+                    const fetched = data.repositories || [];
+                    setRepositories(fetched);
+                    if (
+                        isManualOwnerEntry &&
+                        fetched.length > 0 &&
+                        typeof window !== 'undefined'
+                    ) {
+                        window.localStorage.setItem(
+                            workspaceStorageKey,
+                            selectedOwner,
+                        );
+                    }
                 } else {
                     setRepositories([]);
                 }
@@ -183,7 +220,14 @@ export default function AddRepositoryDialog({
         fetchRepositories();
 
         return () => controller.abort();
-    }, [selectedOwner, provider, organizationSlug, isOpen]);
+    }, [
+        selectedOwner,
+        provider,
+        organizationSlug,
+        isOpen,
+        isManualOwnerEntry,
+        workspaceStorageKey,
+    ]);
 
     const handleRepoSelect = (
         fullName: string,
@@ -324,40 +368,145 @@ export default function AddRepositoryDialog({
                                                 Loading...
                                             </span>
                                         </div>
-                                    ) : owners.length > 0 ? (
+                                    ) : isManualOwnerEntry || owners.length > 0 ? (
                                         <div className="space-y-3">
                                             <div className="flex gap-2">
-                                                <Select
-                                                    value={selectedOwner}
-                                                    onValueChange={(value) => {
-                                                        setSelectedOwner(value);
-                                                        setSearchQuery('');
-                                                    }}
-                                                >
-                                                    <SelectTrigger className="w-[180px] shrink-0">
-                                                        <SelectValue placeholder="Select owner" />
-                                                    </SelectTrigger>
-                                                    <SelectContent>
-                                                        {owners.map((owner) => (
-                                                            <SelectItem
-                                                                key={owner}
-                                                                value={owner}
+                                                {isManualOwnerEntry ? (
+                                                    <div className="flex w-full flex-col gap-2">
+                                                        <div className="flex w-full gap-2">
+                                                            <Input
+                                                                placeholder="Bitbucket workspace slug (e.g. pricorephp)"
+                                                                value={
+                                                                    workspaceInput
+                                                                }
+                                                                onChange={(e) =>
+                                                                    setWorkspaceInput(
+                                                                        e.target
+                                                                            .value,
+                                                                    )
+                                                                }
+                                                                onKeyDown={(
+                                                                    e,
+                                                                ) => {
+                                                                    if (
+                                                                        e.key ===
+                                                                        'Enter'
+                                                                    ) {
+                                                                        e.preventDefault();
+                                                                        const trimmed =
+                                                                            workspaceInput.trim();
+                                                                        if (
+                                                                            trimmed
+                                                                        ) {
+                                                                            setSearchQuery(
+                                                                                '',
+                                                                            );
+                                                                            setSelectedOwner(
+                                                                                trimmed,
+                                                                            );
+                                                                        }
+                                                                    }
+                                                                }}
+                                                                className="flex-1"
+                                                            />
+                                                            <Button
+                                                                type="button"
+                                                                variant="secondary"
+                                                                size="lg"
+                                                                className="shrink-0"
+                                                                disabled={
+                                                                    !workspaceInput.trim() ||
+                                                                    workspaceInput.trim() ===
+                                                                        selectedOwner
+                                                                }
+                                                                onClick={() => {
+                                                                    const trimmed =
+                                                                        workspaceInput.trim();
+                                                                    if (
+                                                                        !trimmed
+                                                                    )
+                                                                        return;
+                                                                    setSearchQuery(
+                                                                        '',
+                                                                    );
+                                                                    setSelectedOwner(
+                                                                        trimmed,
+                                                                    );
+                                                                }}
                                                             >
-                                                                {owner}
-                                                            </SelectItem>
-                                                        ))}
-                                                    </SelectContent>
-                                                </Select>
-                                                <Input
-                                                    placeholder="Search repositories..."
-                                                    value={searchQuery}
-                                                    onChange={(e) =>
-                                                        setSearchQuery(
-                                                            e.target.value,
-                                                        )
-                                                    }
-                                                    disabled={!selectedOwner}
-                                                />
+                                                                Load
+                                                            </Button>
+                                                        </div>
+                                                        <Input
+                                                            placeholder="Search repositories..."
+                                                            value={searchQuery}
+                                                            onChange={(e) =>
+                                                                setSearchQuery(
+                                                                    e.target
+                                                                        .value,
+                                                                )
+                                                            }
+                                                            disabled={
+                                                                !selectedOwner
+                                                            }
+                                                        />
+                                                    </div>
+                                                ) : (
+                                                    <>
+                                                        <Select
+                                                            value={
+                                                                selectedOwner
+                                                            }
+                                                            onValueChange={(
+                                                                value,
+                                                            ) => {
+                                                                setSelectedOwner(
+                                                                    value,
+                                                                );
+                                                                setSearchQuery(
+                                                                    '',
+                                                                );
+                                                            }}
+                                                        >
+                                                            <SelectTrigger className="w-[180px] shrink-0">
+                                                                <SelectValue placeholder="Select owner" />
+                                                            </SelectTrigger>
+                                                            <SelectContent>
+                                                                {owners.map(
+                                                                    (
+                                                                        owner,
+                                                                    ) => (
+                                                                        <SelectItem
+                                                                            key={
+                                                                                owner
+                                                                            }
+                                                                            value={
+                                                                                owner
+                                                                            }
+                                                                        >
+                                                                            {
+                                                                                owner
+                                                                            }
+                                                                        </SelectItem>
+                                                                    ),
+                                                                )}
+                                                            </SelectContent>
+                                                        </Select>
+                                                        <Input
+                                                            placeholder="Search repositories..."
+                                                            value={searchQuery}
+                                                            onChange={(e) =>
+                                                                setSearchQuery(
+                                                                    e.target
+                                                                        .value,
+                                                                )
+                                                            }
+                                                            disabled={
+                                                                !selectedOwner
+                                                            }
+                                                        />
+                                                    </>
+                                                )}
                                             </div>
                                             {loadingRepos ? (
                                                 <div className="flex items-center gap-2 rounded-md border border-input bg-transparent px-3 py-2">
@@ -491,6 +640,16 @@ export default function AddRepositoryDialog({
                                                 <div className="px-2 py-4 text-center text-muted-foreground">
                                                     No repositories found for
                                                     this owner.
+                                                </div>
+                                            ) : isManualOwnerEntry &&
+                                              !selectedOwner ? (
+                                                <div className="px-2 py-4 text-center text-sm text-muted-foreground">
+                                                    Enter a Bitbucket workspace
+                                                    slug to load its
+                                                    repositories. You can find
+                                                    it in your Bitbucket URL:
+                                                    bitbucket.org/{'{'}
+                                                    workspace{'}'}/...
                                                 </div>
                                             ) : null}
                                             <input

--- a/resources/js/components/import-repositories-dialog.tsx
+++ b/resources/js/components/import-repositories-dialog.tsx
@@ -53,6 +53,7 @@ export default function ImportRepositoriesDialog({
     const [provider, setProvider] = useState(defaultProvider);
     const [owners, setOwners] = useState<string[]>([]);
     const [selectedOwner, setSelectedOwner] = useState('');
+    const [workspaceInput, setWorkspaceInput] = useState('');
     const [loadingOwners, setLoadingOwners] = useState(false);
     const [repositories, setRepositories] = useState<RepositorySuggestion[]>(
         [],
@@ -61,6 +62,11 @@ export default function ImportRepositoriesDialog({
     const [selectedRepos, setSelectedRepos] = useState<Set<string>>(new Set());
     const [searchQuery, setSearchQuery] = useState('');
     const [processing, setProcessing] = useState(false);
+
+    // Bitbucket sunset its workspace enumeration API in CHANGE-2770, so the
+    // user has to type their workspace slug instead of picking from a list.
+    const isManualOwnerEntry = provider === 'bitbucket';
+    const workspaceStorageKey = `pricore.bitbucket.workspace.${organizationSlug}`;
 
     const handleClose = () => {
         onClose();
@@ -74,6 +80,7 @@ export default function ImportRepositoriesDialog({
         setProvider(defaultProvider);
         setOwners([]);
         setSelectedOwner('');
+        setWorkspaceInput('');
         setLoadingOwners(false);
         setRepositories([]);
         setLoadingRepos(false);
@@ -84,6 +91,19 @@ export default function ImportRepositoriesDialog({
 
     useEffect(() => {
         if (!isOpen || !provider) {
+            return;
+        }
+
+        if (isManualOwnerEntry) {
+            const remembered =
+                typeof window !== 'undefined'
+                    ? window.localStorage.getItem(workspaceStorageKey) ?? ''
+                    : '';
+            setOwners([]);
+            setSelectedOwner(remembered);
+            setWorkspaceInput(remembered);
+            setLoadingOwners(false);
+            setRepositories([]);
             return;
         }
 
@@ -124,7 +144,13 @@ export default function ImportRepositoriesDialog({
         fetchOwners();
 
         return () => controller.abort();
-    }, [provider, organizationSlug, isOpen]);
+    }, [
+        provider,
+        organizationSlug,
+        isOpen,
+        isManualOwnerEntry,
+        workspaceStorageKey,
+    ]);
 
     useEffect(() => {
         if (!isOpen || !provider || !selectedOwner) {
@@ -147,7 +173,18 @@ export default function ImportRepositoriesDialog({
 
                 if (response.ok) {
                     const data = await response.json();
-                    setRepositories(data.repositories || []);
+                    const fetched = data.repositories || [];
+                    setRepositories(fetched);
+                    if (
+                        isManualOwnerEntry &&
+                        fetched.length > 0 &&
+                        typeof window !== 'undefined'
+                    ) {
+                        window.localStorage.setItem(
+                            workspaceStorageKey,
+                            selectedOwner,
+                        );
+                    }
                 } else {
                     setRepositories([]);
                 }
@@ -166,7 +203,14 @@ export default function ImportRepositoriesDialog({
         fetchRepositories();
 
         return () => controller.abort();
-    }, [selectedOwner, provider, organizationSlug, isOpen]);
+    }, [
+        selectedOwner,
+        provider,
+        organizationSlug,
+        isOpen,
+        isManualOwnerEntry,
+        workspaceStorageKey,
+    ]);
 
     const filteredRepositories = repositories.filter((repo) => {
         if (!searchQuery) return true;
@@ -273,38 +317,88 @@ export default function ImportRepositoriesDialog({
                                 Loading...
                             </span>
                         </div>
-                    ) : owners.length > 0 ? (
+                    ) : isManualOwnerEntry || owners.length > 0 ? (
                         <>
                             <div className="flex gap-2">
-                                <Select
-                                    value={selectedOwner}
-                                    onValueChange={(value) => {
-                                        setSelectedOwner(value);
-                                        setSearchQuery('');
-                                    }}
-                                >
-                                    <SelectTrigger className="w-[180px] shrink-0">
-                                        <SelectValue placeholder="Select owner" />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        {owners.map((owner) => (
-                                            <SelectItem
-                                                key={owner}
-                                                value={owner}
+                                {isManualOwnerEntry ? (
+                                    <form
+                                        className="flex w-full flex-col gap-2"
+                                        onSubmit={(e) => {
+                                            e.preventDefault();
+                                            const trimmed =
+                                                workspaceInput.trim();
+                                            if (!trimmed) return;
+                                            setSearchQuery('');
+                                            setSelectedOwner(trimmed);
+                                        }}
+                                    >
+                                        <div className="flex w-full gap-2">
+                                            <Input
+                                                placeholder="Bitbucket workspace slug (e.g. pricorephp)"
+                                                value={workspaceInput}
+                                                onChange={(e) =>
+                                                    setWorkspaceInput(
+                                                        e.target.value,
+                                                    )
+                                                }
+                                                className="flex-1"
+                                            />
+                                            <Button
+                                                type="submit"
+                                                variant="secondary"
+                                                size="lg"
+                                                className="shrink-0"
+                                                disabled={
+                                                    !workspaceInput.trim() ||
+                                                    workspaceInput.trim() ===
+                                                        selectedOwner
+                                                }
                                             >
-                                                {owner}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
-                                <Input
-                                    placeholder="Search repositories..."
-                                    value={searchQuery}
-                                    onChange={(e) =>
-                                        setSearchQuery(e.target.value)
-                                    }
-                                    disabled={!selectedOwner}
-                                />
+                                                Load
+                                            </Button>
+                                        </div>
+                                        <Input
+                                            placeholder="Search repositories..."
+                                            value={searchQuery}
+                                            onChange={(e) =>
+                                                setSearchQuery(e.target.value)
+                                            }
+                                            disabled={!selectedOwner}
+                                        />
+                                    </form>
+                                ) : (
+                                    <>
+                                        <Select
+                                            value={selectedOwner}
+                                            onValueChange={(value) => {
+                                                setSelectedOwner(value);
+                                                setSearchQuery('');
+                                            }}
+                                        >
+                                            <SelectTrigger className="w-[180px] shrink-0">
+                                                <SelectValue placeholder="Select owner" />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                {owners.map((owner) => (
+                                                    <SelectItem
+                                                        key={owner}
+                                                        value={owner}
+                                                    >
+                                                        {owner}
+                                                    </SelectItem>
+                                                ))}
+                                            </SelectContent>
+                                        </Select>
+                                        <Input
+                                            placeholder="Search repositories..."
+                                            value={searchQuery}
+                                            onChange={(e) =>
+                                                setSearchQuery(e.target.value)
+                                            }
+                                            disabled={!selectedOwner}
+                                        />
+                                    </>
+                                )}
                             </div>
 
                             {loadingRepos ? (
@@ -396,6 +490,13 @@ export default function ImportRepositoriesDialog({
                             ) : selectedOwner && repositories.length === 0 ? (
                                 <div className="px-2 py-4 text-center text-muted-foreground">
                                     No repositories found for this owner.
+                                </div>
+                            ) : isManualOwnerEntry && !selectedOwner ? (
+                                <div className="px-2 py-4 text-center text-sm text-muted-foreground">
+                                    Enter a Bitbucket workspace slug to load
+                                    its repositories. You can find it in the
+                                    Bitbucket URL: bitbucket.org/{'{'}
+                                    workspace{'}'}/...
                                 </div>
                             ) : null}
                         </>

--- a/tests/Feature/Domains/Repository/BitbucketProviderTest.php
+++ b/tests/Feature/Domains/Repository/BitbucketProviderTest.php
@@ -1,8 +1,33 @@
 <?php
 
+use App\Domains\Repository\Exceptions\GitProviderException;
 use App\Domains\Repository\Services\GitProviders\BitbucketProvider;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+
+function bitbucketProvider(): BitbucketProvider
+{
+    return new BitbucketProvider('', [
+        'email' => 'user@example.com',
+        'api_token' => 'token',
+    ]);
+}
+
+it('returns no owners because Bitbucket sunset cross-workspace enumeration', function () {
+    Http::fake();
+
+    expect(bitbucketProvider()->getOwners())->toBe([]);
+
+    Http::assertNothingSent();
+});
+
+it('throws when called without a workspace because cross-workspace listing was sunset', function () {
+    expect(fn () => bitbucketProvider()->getRepositories())
+        ->toThrow(GitProviderException::class, 'Bitbucket requires a workspace');
+
+    expect(fn () => bitbucketProvider()->getRepositories(''))
+        ->toThrow(GitProviderException::class, 'Bitbucket requires a workspace');
+});
 
 it('paginates through all workspace repositories without dropping the next-page query', function () {
     $page1 = [
@@ -29,12 +54,7 @@ it('paginates through all workspace repositories without dropping the next-page 
         'api.bitbucket.org/2.0/repositories/acme*' => Http::response($page1, 200),
     ]);
 
-    $bitbucketProvider = new BitbucketProvider('', [
-        'email' => 'user@example.com',
-        'api_token' => 'token',
-    ]);
-
-    $repositories = $bitbucketProvider->getRepositories('acme');
+    $repositories = bitbucketProvider()->getRepositories('acme');
 
     expect($repositories)->toHaveCount(150);
     expect($repositories[0]->fullName)->toBe('acme/repo-1');
@@ -43,4 +63,15 @@ it('paginates through all workspace repositories without dropping the next-page 
     Http::assertSentCount(2);
     Http::assertSent(fn (Request $request) => str_contains($request->url(), 'page=2')
         && str_contains($request->url(), 'pagelen=100'));
+});
+
+it('translates 403 scope failures on the workspace repos endpoint into a helpful message', function () {
+    Http::fake([
+        'api.bitbucket.org/2.0/repositories/acme*' => Http::response([
+            'error' => ['detail' => ['required' => ['read:repository:bitbucket']]],
+        ], 403),
+    ]);
+
+    expect(fn () => bitbucketProvider()->getRepositories('acme'))
+        ->toThrow(GitProviderException::class, 'missing required scopes');
 });

--- a/tests/Feature/Domains/Repository/BitbucketProviderTest.php
+++ b/tests/Feature/Domains/Repository/BitbucketProviderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use App\Domains\Repository\Services\GitProviders\BitbucketProvider;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
+it('paginates through all workspace repositories without dropping the next-page query', function () {
+    $page1 = [
+        'values' => array_map(fn (int $i) => [
+            'slug' => "repo-{$i}",
+            'full_name' => "acme/repo-{$i}",
+            'is_private' => true,
+            'description' => null,
+        ], range(1, 100)),
+        'next' => 'https://api.bitbucket.org/2.0/repositories/acme?page=2&pagelen=100',
+    ];
+
+    $page2 = [
+        'values' => array_map(fn (int $i) => [
+            'slug' => "repo-{$i}",
+            'full_name' => "acme/repo-{$i}",
+            'is_private' => true,
+            'description' => null,
+        ], range(101, 150)),
+    ];
+
+    Http::fake([
+        'api.bitbucket.org/2.0/repositories/acme?page=2*' => Http::response($page2, 200),
+        'api.bitbucket.org/2.0/repositories/acme*' => Http::response($page1, 200),
+    ]);
+
+    $bitbucketProvider = new BitbucketProvider('', [
+        'email' => 'user@example.com',
+        'api_token' => 'token',
+    ]);
+
+    $repositories = $bitbucketProvider->getRepositories('acme');
+
+    expect($repositories)->toHaveCount(150);
+    expect($repositories[0]->fullName)->toBe('acme/repo-1');
+    expect($repositories[149]->fullName)->toBe('acme/repo-150');
+
+    Http::assertSentCount(2);
+    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'page=2')
+        && str_contains($request->url(), 'pagelen=100'));
+});


### PR DESCRIPTION
Closes #87. Supersedes #109.

## What was broken

- **Pagination cursor bug**: `BitbucketProvider` reset `$params` to `[]` on subsequent pages, which Laravel forwarded as `['query' => []]`. Guzzle then ran `http_build_query([])` and replaced the URL's query string with `""`, stripping the `?page=2&pagelen=100` from the cursor. Each "next" call re-fetched page 1, so the loop spun until PHP's 30s execution limit killed the curl handle.
- **Username surfaced as a workspace owner**: `getOwners()` injected the authenticated user's `username` from `/user`. Selecting it hit `/repositories/{username}` and 404'd because users are not workspaces under the new permissions model.
- **Cross-workspace enumeration removed by Atlassian** (CHANGE-2770, sunset 2026-04-14): `/workspaces`, `/user/permissions/workspaces`, and `/repositories?role=…` now return HTTP 410 with no replacement API. There is no way to list which workspaces a user belongs to.

## Fix

- Pagination loops use `params === [] ? get(\$url) : get(\$url, \$params)` so the cursor's query string survives.
- `getOwners()` returns `[]` and makes no API call.
- `getRepositories(\$owner)` requires `\$owner` (throws a clear error otherwise) and uses `/repositories/{owner}`, which still works.
- Both Import and Add Repository dialogs replace the owner dropdown with a workspace-slug text input + Load button when Bitbucket is selected. Last-used slug is remembered per organization in `localStorage`.

## Verification

- `composer run phpstan`, `vendor/bin/pint --dirty`, `npm run types`, `npm run lint`, `npm run build`, `php artisan test` — all clean (489 passing).
- Manually verified end-to-end against `pricorephp` workspace (real Bitbucket account): repos load, import + add flows both work, `localStorage` remembers the slug across reloads.