### PR TITLE
refactor(organizations): apply policy checks consistently across controllers

### DIFF
--- a/app/Domains/Organization/Http/Controllers/DismissOnboardingController.php
+++ b/app/Domains/Organization/Http/Controllers/DismissOnboardingController.php
@@ -5,12 +5,17 @@ namespace App\Domains\Organization\Http\Controllers;
 use App\Http\Controllers\Controller;
 use App\Models\Organization;
 use App\Models\User;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\RedirectResponse;
 
 class DismissOnboardingController extends Controller
 {
+    use AuthorizesRequests;
+
     public function __invoke(Organization $organization): RedirectResponse
     {
+        $this->authorize('view', $organization);
+
         /** @var User $user */
         $user = auth()->user();
 

--- a/app/Domains/Organization/Http/Controllers/MemberController.php
+++ b/app/Domains/Organization/Http/Controllers/MemberController.php
@@ -57,6 +57,8 @@ class MemberController
 
     public function store(AddMemberRequest $request, Organization $organization, SendOrganizationInvitationAction $sendInvitation): RedirectResponse
     {
+        $this->authorize('manageMembers', $organization);
+
         $email = $request->validated('email');
         $role = OrganizationRole::from($request->validated('role'));
 
@@ -87,6 +89,8 @@ class MemberController
 
     public function update(UpdateMemberRoleRequest $request, Organization $organization, OrganizationUser $member, RecordActivityTask $recordActivity): RedirectResponse
     {
+        $this->authorize('manageMembers', $organization);
+
         if ($member->organization_uuid !== $organization->uuid) {
             abort(404);
         }

--- a/app/Domains/Organization/Http/Controllers/OrganizationController.php
+++ b/app/Domains/Organization/Http/Controllers/OrganizationController.php
@@ -36,6 +36,8 @@ class OrganizationController extends Controller
 
     public function show(Organization $organization): Response
     {
+        $this->authorize('view', $organization);
+
         /** @var User $user */
         $user = auth()->user();
 

--- a/app/Domains/Organization/Http/Controllers/SettingsController.php
+++ b/app/Domains/Organization/Http/Controllers/SettingsController.php
@@ -34,6 +34,8 @@ class SettingsController
 
     public function update(UpdateOrganizationRequest $request, Organization $organization): RedirectResponse
     {
+        $this->authorize('viewSettings', $organization);
+
         $user = $request->user();
         $isOwner = $user !== null && $organization->owner_uuid === $user->uuid;
 

--- a/app/Domains/Package/Http/Controllers/PackageController.php
+++ b/app/Domains/Package/Http/Controllers/PackageController.php
@@ -31,6 +31,8 @@ class PackageController extends Controller
 
     public function index(Organization $organization): Response
     {
+        $this->authorize('view', $organization);
+
         $packages = $organization->packages()
             ->with(['repository', 'mirror'])
             ->withCount('versions')
@@ -72,6 +74,8 @@ class PackageController extends Controller
 
     public function show(Request $request, Organization $organization, Package $package): Response
     {
+        $this->authorize('view', $organization);
+
         if ($request->user() && ! $request->hasAny(['query', 'type', 'page', 'version'])) {
             $this->recordPackageView->handle($request->user(), $package);
         }

--- a/app/Domains/Repository/Http/Controllers/Api/RepositorySuggestionController.php
+++ b/app/Domains/Repository/Http/Controllers/Api/RepositorySuggestionController.php
@@ -12,13 +12,18 @@ use App\Models\Organization;
 use App\Models\Repository;
 use App\Models\User;
 use App\Models\UserGitCredential;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class RepositorySuggestionController extends Controller
 {
+    use AuthorizesRequests;
+
     public function index(Request $request, Organization $organization): JsonResponse
     {
+        $this->authorize('viewSettings', $organization);
+
         $provider = GitProvider::tryFrom($request->query('provider'));
 
         if (! $provider) {
@@ -75,6 +80,8 @@ class RepositorySuggestionController extends Controller
 
     public function owners(Request $request, Organization $organization): JsonResponse
     {
+        $this->authorize('viewSettings', $organization);
+
         $provider = GitProvider::tryFrom($request->query('provider'));
 
         if (! $provider) {

--- a/app/Domains/Repository/Http/Controllers/RepositoryController.php
+++ b/app/Domains/Repository/Http/Controllers/RepositoryController.php
@@ -22,6 +22,7 @@ use App\Models\Organization;
 use App\Models\Repository;
 use App\Models\User;
 use App\Models\UserGitCredential;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -29,6 +30,8 @@ use Inertia\Response;
 
 class RepositoryController extends Controller
 {
+    use AuthorizesRequests;
+
     public function __construct(
         protected ExtractRepositoryNameAction $extractRepositoryNameAction,
         protected RegisterWebhookAction $registerWebhookAction,
@@ -38,6 +41,8 @@ class RepositoryController extends Controller
 
     public function index(Organization $organization): Response
     {
+        $this->authorize('view', $organization);
+
         $repositories = $organization->repositories()
             ->withCount('packages')
             ->orderBy('name')
@@ -67,6 +72,8 @@ class RepositoryController extends Controller
 
     public function store(StoreRepositoryRequest $request, Organization $organization): RedirectResponse
     {
+        $this->authorize('deleteRepository', $organization);
+
         $name = $request->name ?? $this->extractRepositoryNameAction->handle(
             $request->repo_identifier,
             GitProvider::from($request->provider)
@@ -119,6 +126,8 @@ class RepositoryController extends Controller
         Organization $organization,
         BulkCreateRepositoriesAction $bulkCreateAction,
     ): RedirectResponse {
+        $this->authorize('deleteRepository', $organization);
+
         /** @var User $user */
         $user = $request->user();
 
@@ -136,6 +145,8 @@ class RepositoryController extends Controller
 
     public function show(Organization $organization, Repository $repository): Response
     {
+        $this->authorize('view', $organization);
+
         $repository->load('organization');
         $repository->loadCount('packages');
 
@@ -178,6 +189,8 @@ class RepositoryController extends Controller
 
     public function update(Organization $organization, Repository $repository): RedirectResponse
     {
+        $this->authorize('deleteRepository', $organization);
+
         // Placeholder for future updates
         return redirect()
             ->route('organizations.repositories.edit', [$organization, $repository])

--- a/app/Domains/Repository/Http/Controllers/SyncRepositoryController.php
+++ b/app/Domains/Repository/Http/Controllers/SyncRepositoryController.php
@@ -7,12 +7,17 @@ use App\Domains\Repository\Jobs\SyncRepositoryJob;
 use App\Http\Controllers\Controller;
 use App\Models\Organization;
 use App\Models\Repository;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\RedirectResponse;
 
 class SyncRepositoryController extends Controller
 {
+    use AuthorizesRequests;
+
     public function __invoke(Organization $organization, Repository $repository): RedirectResponse
     {
+        $this->authorize('deleteRepository', $organization);
+
         $repository->update(['sync_status' => RepositorySyncStatus::Pending]);
 
         SyncRepositoryJob::dispatch($repository);

--- a/app/Domains/Repository/Http/Controllers/SyncWebhookController.php
+++ b/app/Domains/Repository/Http/Controllers/SyncWebhookController.php
@@ -6,15 +6,20 @@ use App\Domains\Repository\Actions\RegisterWebhookAction;
 use App\Http\Controllers\Controller;
 use App\Models\Organization;
 use App\Models\Repository;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\RedirectResponse;
 
 class SyncWebhookController extends Controller
 {
+    use AuthorizesRequests;
+
     public function __invoke(
         Organization $organization,
         Repository $repository,
         RegisterWebhookAction $registerWebhookAction,
     ): RedirectResponse {
+        $this->authorize('deleteRepository', $organization);
+
         $success = $registerWebhookAction->handle($repository);
 
         if ($success) {

--- a/app/Domains/Security/Http/Controllers/ScanSecurityController.php
+++ b/app/Domains/Security/Http/Controllers/ScanSecurityController.php
@@ -5,12 +5,17 @@ namespace App\Domains\Security\Http\Controllers;
 use App\Domains\Security\Actions\ScanOrganizationPackagesAction;
 use App\Http\Controllers\Controller;
 use App\Models\Organization;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\RedirectResponse;
 
 class ScanSecurityController extends Controller
 {
+    use AuthorizesRequests;
+
     public function __invoke(Organization $organization, ScanOrganizationPackagesAction $scanOrganizationPackagesAction): RedirectResponse
     {
+        $this->authorize('deleteRepository', $organization);
+
         if (! $organization->security_audits_enabled) {
             return redirect()->back()->with('status', 'Security audits are disabled for this organization.');
         }

--- a/app/Domains/Security/Http/Controllers/SecurityOverviewController.php
+++ b/app/Domains/Security/Http/Controllers/SecurityOverviewController.php
@@ -10,6 +10,7 @@ use App\Models\AdvisorySyncMetadata;
 use App\Models\Organization;
 use App\Models\Package;
 use App\Models\PackageVersion;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
@@ -17,8 +18,12 @@ use Inertia\Response;
 
 class SecurityOverviewController extends Controller
 {
+    use AuthorizesRequests;
+
     public function index(Request $request, Organization $organization): Response
     {
+        $this->authorize('view', $organization);
+
         $severityFilter = $request->query('severity', '');
 
         // Latest stable version + all dev versions per package

--- a/app/Domains/Token/Http/Controllers/TokenController.php
+++ b/app/Domains/Token/Http/Controllers/TokenController.php
@@ -11,12 +11,15 @@ use App\Domains\Token\Requests\StoreAccessTokenRequest;
 use App\Http\Controllers\Controller;
 use App\Models\AccessToken;
 use App\Models\Organization;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\RedirectResponse;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class TokenController extends Controller
 {
+    use AuthorizesRequests;
+
     public function __construct(
         protected CreateAccessTokenAction $createAccessToken,
         protected RecordActivityTask $recordActivity,
@@ -24,6 +27,8 @@ class TokenController extends Controller
 
     public function index(Organization $organization): Response
     {
+        $this->authorize('viewSettings', $organization);
+
         $tokens = AccessToken::query()
             ->where('organization_uuid', $organization->uuid)
             ->orderBy('created_at', 'desc')
@@ -38,6 +43,8 @@ class TokenController extends Controller
 
     public function store(StoreAccessTokenRequest $request, Organization $organization): Response
     {
+        $this->authorize('viewSettings', $organization);
+
         $result = $this->createAccessToken->handle(
             organization: $organization,
             user: null,
@@ -60,6 +67,8 @@ class TokenController extends Controller
 
     public function destroy(Organization $organization, AccessToken $token): RedirectResponse
     {
+        $this->authorize('viewSettings', $organization);
+
         if ($token->organization_uuid !== $organization->uuid) {
             abort(403);
         }

--- a/app/Http/Middleware/EnsureOrganizationMembership.php
+++ b/app/Http/Middleware/EnsureOrganizationMembership.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Organization;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureOrganizationMembership
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $organization = $request->route('organization');
+        $user = $request->user();
+
+        if (! $organization instanceof Organization || $user === null) {
+            abort(403);
+        }
+
+        $isMember = $organization->members()
+            ->where('user_uuid', $user->uuid)
+            ->exists();
+
+        if (! $isMember) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Policies/OrganizationPolicy.php
+++ b/app/Policies/OrganizationPolicy.php
@@ -8,6 +8,11 @@ use App\Models\User;
 
 class OrganizationPolicy
 {
+    public function view(User $user, Organization $organization): bool
+    {
+        return $organization->members()->where('user_uuid', $user->uuid)->exists();
+    }
+
     public function viewSettings(User $user, Organization $organization): bool
     {
         /** @var User|null $member */

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Middleware\ComposerTokenAuth;
+use App\Http\Middleware\EnsureOrganizationMembership;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
 use App\Http\Middleware\TrackOrganizationAccess;
@@ -46,6 +47,7 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $middleware->alias([
             'composer.token' => ComposerTokenAuth::class,
+            'organization.member' => EnsureOrganizationMembership::class,
             'track.organization' => TrackOrganizationAccess::class,
         ]);
     })

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,8 +48,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('organizations', [OrganizationController::class, 'index'])->name('organizations.index');
     Route::post('organizations', [OrganizationController::class, 'store'])->name('organizations.store');
 
-    // Organization routes (with access tracking)
-    Route::middleware('track.organization')->group(function () {
+    // Organization routes (membership-gated, with access tracking)
+    Route::middleware(['organization.member', 'track.organization'])->group(function () {
         Route::get('organizations/{organization:slug}', [OrganizationController::class, 'show'])->name('organizations.show');
         Route::delete('organizations/{organization:slug}', [OrganizationController::class, 'destroy'])->name('organizations.destroy');
         Route::post('organizations/{organization:slug}/dismiss-onboarding', DismissOnboardingController::class)->name('organizations.dismiss-onboarding');

--- a/tests/Feature/Security/OrganizationAuthorizationTest.php
+++ b/tests/Feature/Security/OrganizationAuthorizationTest.php
@@ -1,0 +1,140 @@
+<?php
+
+use App\Domains\Organization\Contracts\Enums\OrganizationRole;
+use App\Models\AccessToken;
+use App\Models\Organization;
+use App\Models\OrganizationUser;
+use App\Models\Package;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+uses()->group('security', 'authorization');
+
+beforeEach(function () {
+    $owner = User::factory()->create();
+    $this->organization = Organization::factory()->create(['owner_uuid' => $owner->uuid]);
+    $this->organization->members()->attach($owner->uuid, [
+        'uuid' => Str::uuid()->toString(),
+        'role' => OrganizationRole::Owner->value,
+    ]);
+
+    $this->repository = Repository::factory()->forOrganization($this->organization)->create();
+    $this->package = Package::factory()
+        ->forOrganization($this->organization)
+        ->forRepository($this->repository)
+        ->create();
+    $this->token = AccessToken::factory()->forOrganization($this->organization)->create();
+    $this->memberRow = OrganizationUser::factory()
+        ->forOrganization($this->organization)
+        ->member()
+        ->create();
+
+    $this->nonMember = User::factory()->create();
+
+    $this->plainMember = User::factory()->create();
+    $this->organization->members()->attach($this->plainMember->uuid, [
+        'uuid' => Str::uuid()->toString(),
+        'role' => OrganizationRole::Member->value,
+    ]);
+});
+
+function guardedOrgRequests(TestCase $test): array
+{
+    /** @var Organization $organization */
+    $organization = $test->organization;
+    /** @var Repository $repository */
+    $repository = $test->repository;
+    /** @var Package $package */
+    $package = $test->package;
+    /** @var AccessToken $token */
+    $token = $test->token;
+    /** @var OrganizationUser $memberRow */
+    $memberRow = $test->memberRow;
+
+    $slug = $organization->slug;
+
+    return [
+        'organizations.show' => ['GET', "/organizations/{$slug}", []],
+        'organizations.dismiss-onboarding' => ['POST', "/organizations/{$slug}/dismiss-onboarding", []],
+        'organizations.packages.index' => ['GET', "/organizations/{$slug}/packages", []],
+        'organizations.packages.show' => ['GET', "/organizations/{$slug}/packages/{$package->uuid}", []],
+        'organizations.repositories.index' => ['GET', "/organizations/{$slug}/repositories", []],
+        'organizations.repositories.suggest' => ['GET', "/organizations/{$slug}/repositories/suggest?provider=github", []],
+        'organizations.repositories.owners' => ['GET', "/organizations/{$slug}/repositories/owners?provider=github", []],
+        'organizations.repositories.show' => ['GET', "/organizations/{$slug}/repositories/{$repository->uuid}", []],
+        'organizations.repositories.store' => ['POST', "/organizations/{$slug}/repositories", [
+            'provider' => 'github',
+            'repo_identifier' => 'foo/bar',
+            'default_branch' => 'main',
+        ]],
+        'organizations.repositories.bulk-store' => ['POST', "/organizations/{$slug}/repositories/bulk", [
+            'provider' => 'github',
+            'repositories' => [['repo_identifier' => 'foo/bar']],
+        ]],
+        'organizations.repositories.update' => ['PATCH', "/organizations/{$slug}/repositories/{$repository->uuid}", []],
+        'organizations.repositories.sync' => ['POST', "/organizations/{$slug}/repositories/{$repository->uuid}/sync", []],
+        'organizations.repositories.webhook.sync' => ['POST', "/organizations/{$slug}/repositories/{$repository->uuid}/webhook/sync", []],
+        'organizations.security.index' => ['GET', "/organizations/{$slug}/security", []],
+        'organizations.security.scan' => ['POST', "/organizations/{$slug}/security/scan", []],
+        'organizations.settings.update' => ['PATCH', "/organizations/{$slug}/settings/general", ['name' => 'New Name']],
+        'organizations.settings.members.store' => ['POST', "/organizations/{$slug}/settings/members", [
+            'email' => 'new@example.com',
+            'role' => OrganizationRole::Member->value,
+        ]],
+        'organizations.settings.members.update' => ['PATCH', "/organizations/{$slug}/settings/members/{$memberRow->uuid}", [
+            'role' => OrganizationRole::Admin->value,
+        ]],
+        'organizations.settings.tokens.index' => ['GET', "/organizations/{$slug}/settings/tokens", []],
+        'organizations.settings.tokens.store' => ['POST', "/organizations/{$slug}/settings/tokens", ['name' => 'pwn']],
+        'organizations.settings.tokens.destroy' => ['DELETE', "/organizations/{$slug}/settings/tokens/{$token->uuid}", []],
+    ];
+}
+
+it('forbids non-members from every guarded org route', function () {
+    foreach (guardedOrgRequests($this) as $name => [$method, $url, $body]) {
+        $response = $this->actingAs($this->nonMember)->call($method, $url, $body);
+
+        expect($response->status())->toBe(
+            403,
+            "non-member should be forbidden from {$name}, got {$response->status()}"
+        );
+    }
+});
+
+it('forbids plain Member role from admin-only org routes', function () {
+    $memberAllowed = [
+        'organizations.show',
+        'organizations.dismiss-onboarding',
+        'organizations.packages.index',
+        'organizations.packages.show',
+        'organizations.repositories.index',
+        'organizations.repositories.show',
+        'organizations.security.index',
+    ];
+
+    foreach (guardedOrgRequests($this) as $name => [$method, $url, $body]) {
+        if (in_array($name, $memberAllowed, true)) {
+            continue;
+        }
+
+        $response = $this->actingAs($this->plainMember)->call($method, $url, $body);
+
+        expect($response->status())->toBe(
+            403,
+            "plain member should be forbidden from {$name}, got {$response->status()}"
+        );
+    }
+});
+
+it('rejects token creation by a non-member and persists nothing', function () {
+    $organization = Organization::factory()->create();
+    $attacker = User::factory()->create();
+
+    $this->actingAs($attacker)
+        ->post("/organizations/{$organization->slug}/settings/tokens", ['name' => 'pwn'])
+        ->assertForbidden();
+
+    expect(AccessToken::where('organization_uuid', $organization->uuid)->count())->toBe(0);
+});

--- a/tests/Feature/Security/OrganizationAuthorizationTest.php
+++ b/tests/Feature/Security/OrganizationAuthorizationTest.php
@@ -128,6 +128,15 @@ it('forbids plain Member role from admin-only org routes', function () {
     }
 });
 
+it('blocks non-members at the route middleware before the controller runs', function () {
+    $organization = Organization::factory()->create();
+    $outsider = User::factory()->create();
+
+    $this->actingAs($outsider)
+        ->get("/organizations/{$organization->slug}")
+        ->assertForbidden();
+});
+
 it('rejects token creation by a non-member and persists nothing', function () {
     $organization = Organization::factory()->create();
     $attacker = User::factory()->create();


### PR DESCRIPTION
Aligns organization-scoped controllers with the existing `OrganizationPolicy` pattern used by `SshKeyController`, `MirrorController`, and friends. Adds an `OrganizationPolicy::view` ability so non-admin members keep their existing read access to dashboard / packages / repositories / security overview.

Also adds an `organization.member` middleware on the org route group so any new route under that prefix is membership-gated by default.