### PR TITLE
fix(auth): persist GitLab instance URL on OAuth credentials

### DIFF
--- a/app/Domains/Auth/Actions/SyncUserGitLabCredentialAction.php
+++ b/app/Domains/Auth/Actions/SyncUserGitLabCredentialAction.php
@@ -8,13 +8,15 @@ use App\Models\UserGitCredential;
 
 class SyncUserGitLabCredentialAction
 {
-    public function handle(User $user, string $token): bool
+    public function handle(User $user, string $token, string $url): bool
     {
+        $credentials = ['token' => $token, 'url' => $url];
+
         $credential = $user->gitCredentials()->where('provider', GitProvider::GitLab)->first();
 
         if ($credential) {
             $credential->update([
-                'credentials' => ['token' => $token],
+                'credentials' => $credentials,
             ]);
 
             return true;
@@ -23,7 +25,7 @@ class SyncUserGitLabCredentialAction
         UserGitCredential::create([
             'user_uuid' => $user->uuid,
             'provider' => GitProvider::GitLab,
-            'credentials' => ['token' => $token],
+            'credentials' => $credentials,
         ]);
 
         return false;

--- a/app/Http/Controllers/Auth/GitLabAuthController.php
+++ b/app/Http/Controllers/Auth/GitLabAuthController.php
@@ -94,7 +94,11 @@ class GitLabAuthController extends Controller
         $updateProfile->handle($user, $gitlabUser);
 
         /** @var TwoUser $gitlabUser */
-        $updated = $syncCredential->handle($user, $gitlabUser->token);
+        $updated = $syncCredential->handle(
+            $user,
+            $gitlabUser->token,
+            rtrim(config('services.gitlab.instance_uri'), '/'),
+        );
 
         $message = $updated
             ? 'GitLab credentials updated successfully.'

--- a/app/Http/Controllers/Auth/GitLabAuthController.php
+++ b/app/Http/Controllers/Auth/GitLabAuthController.php
@@ -95,9 +95,9 @@ class GitLabAuthController extends Controller
 
         /** @var TwoUser $gitlabUser */
         $updated = $syncCredential->handle(
-            $user,
-            $gitlabUser->token,
-            rtrim(config('services.gitlab.instance_uri'), '/'),
+            user: $user,
+            token: $gitlabUser->token,
+            url: rtrim(config('services.gitlab.instance_uri'), '/'),
         );
 
         $message = $updated

--- a/database/migrations/2026_06_07_172347_backfill_gitlab_credential_url.php
+++ b/database/migrations/2026_06_07_172347_backfill_gitlab_credential_url.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Domains\Repository\Contracts\Enums\GitProvider;
+use App\Models\UserGitCredential;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $defaultUrl = rtrim((string) config('services.gitlab.instance_uri'), '/');
+
+        if ($defaultUrl === '') {
+            return;
+        }
+
+        UserGitCredential::query()
+            ->where('provider', GitProvider::GitLab)
+            ->get()
+            ->each(function (UserGitCredential $credential) use ($defaultUrl): void {
+                if (! empty($credential->credentials['url'] ?? null)) {
+                    return;
+                }
+
+                $credential->credentials = [
+                    ...$credential->credentials,
+                    'url' => $defaultUrl,
+                ];
+
+                $credential->save();
+            });
+    }
+
+    public function down(): void
+    {
+        // Not reversible — we can't distinguish backfilled URLs from user-set ones.
+    }
+};

--- a/database/migrations/2026_06_07_172347_backfill_gitlab_credential_url.php
+++ b/database/migrations/2026_06_07_172347_backfill_gitlab_credential_url.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Domains\Repository\Contracts\Enums\GitProvider;
+use App\Models\Repository;
 use App\Models\UserGitCredential;
 use Illuminate\Database\Migrations\Migration;
 
@@ -28,6 +29,26 @@ return new class extends Migration
                 ];
 
                 $credential->save();
+            });
+
+        Repository::query()
+            ->where('provider', GitProvider::GitLab)
+            ->whereNull('custom_base_url')
+            ->whereNotNull('credential_user_uuid')
+            ->get()
+            ->each(function (Repository $repository): void {
+                $credential = UserGitCredential::query()
+                    ->where('user_uuid', $repository->credential_user_uuid)
+                    ->where('provider', GitProvider::GitLab)
+                    ->first();
+
+                $url = $credential?->credentials['url'] ?? null;
+
+                if (! $url) {
+                    return;
+                }
+
+                $repository->update(['custom_base_url' => $url]);
             });
     }
 

--- a/tests/Feature/Auth/GitLabAuthenticationTest.php
+++ b/tests/Feature/Auth/GitLabAuthenticationTest.php
@@ -241,8 +241,11 @@ test('connect callback creates git credential for user', function () {
         ->where('provider', 'gitlab')
         ->first();
 
+    $expectedUrl = rtrim((string) config('services.gitlab.instance_uri'), '/');
+
     expect($credential)->not->toBeNull()
-        ->and($credential->credentials['token'])->toBe('glpat-elevated_token');
+        ->and($credential->credentials['token'])->toBe('glpat-elevated_token')
+        ->and($credential->credentials['url'])->toBe($expectedUrl);
 });
 
 test('connect callback updates existing credential', function () {
@@ -262,7 +265,30 @@ test('connect callback updates existing credential', function () {
     $response->assertRedirect(route('settings.git-credentials'));
     $response->assertSessionHas('status', 'GitLab credentials updated successfully.');
 
-    expect(UserGitCredential::where('user_uuid', $user->uuid)->count())->toBe(1);
+    $credential = UserGitCredential::where('user_uuid', $user->uuid)->sole();
+    $expectedUrl = rtrim((string) config('services.gitlab.instance_uri'), '/');
+
+    expect($credential->credentials['token'])->toBe('glpat-elevated_token')
+        ->and($credential->credentials['url'])->toBe($expectedUrl);
+});
+
+test('connect callback persists configured GitLab instance URI', function () {
+    config()->set('services.gitlab.instance_uri', 'https://gitlab.example.com/');
+
+    $user = User::factory()->withGitLab()->create();
+
+    $socialiteUser = mockGitLabSocialiteUser(['id' => $user->gitlab_id, 'token' => 'glpat-elevated_token']);
+    mockGitLabSocialiteCallback($socialiteUser);
+
+    $this->actingAs($user)
+        ->withSession(['gitlab_oauth_intent' => GitLabOAuthIntent::Connect])
+        ->get(route('auth.gitlab.callback'));
+
+    $credential = UserGitCredential::where('user_uuid', $user->uuid)
+        ->where('provider', 'gitlab')
+        ->sole();
+
+    expect($credential->credentials['url'])->toBe('https://gitlab.example.com');
 });
 
 test('connect callback without auth redirects to login', function () {


### PR DESCRIPTION
Closes #134.

- `SyncUserGitLabCredentialAction` now persists `services.gitlab.instance_uri` onto the credential during the OAuth connect flow, so self-hosted GitLab API calls hit the configured instance instead of falling back to `https://gitlab.com`.
- Migration backfills `url` on existing GitLab credentials and `custom_base_url` on existing GitLab repositories from the same config value.