### PR TITLE
feat(mirror): support mirroring Composer v2 registries

### DIFF
--- a/app/Domains/Mirror/Services/RegistryClient/RegistryClientFactory.php
+++ b/app/Domains/Mirror/Services/RegistryClient/RegistryClientFactory.php
@@ -80,6 +80,19 @@ class RegistryClientFactory
         array $rootMetadata,
         Mirror $mirror,
     ): RegistryClientInterface {
+        // Composer v2 format: a metadata-url template points to per-package
+        // metadata files. Prioritized over the v1 formats below.
+        $metadataUrl = $rootMetadata['metadata-url'] ?? null;
+
+        if (is_string($metadataUrl) && $metadataUrl !== '') {
+            return new V2RegistryClient(
+                httpClient: $httpClient,
+                baseUrl: $mirror->url,
+                metadataUrlTemplate: $metadataUrl,
+                availablePackages: static::resolveAvailablePackages($rootMetadata, $mirror->url),
+            );
+        }
+
         // Inline format: packages key contains all package data directly
         $packages = $rootMetadata['packages'] ?? null;
 
@@ -98,6 +111,32 @@ class RegistryClientFactory
 
         throw new MirrorSyncException(
             "Unsupported registry format at {$mirror->url}: no packages or includes found in packages.json"
+        );
+    }
+
+    /**
+     * Resolve the list of mirrorable package names from a Composer v2 root.
+     *
+     * Only registries that advertise their packages via "available-packages"
+     * (optionally narrowed by "available-package-patterns") can be enumerated.
+     * Registries that expose packages solely through a "list" endpoint — such
+     * as Packagist — are not supported, as eagerly mirroring them is impractical.
+     *
+     * @param  array<string, mixed>  $rootMetadata
+     * @return array<int, string>
+     */
+    protected static function resolveAvailablePackages(array $rootMetadata, string $baseUrl): array
+    {
+        $availablePackages = $rootMetadata['available-packages'] ?? null;
+
+        if (is_array($availablePackages)) {
+            return array_values(array_filter($availablePackages, 'is_string'));
+        }
+
+        throw new MirrorSyncException(
+            "Unsupported Composer v2 registry at {$baseUrl}: it does not advertise an ".
+            '"available-packages" list. Registries that only expose a "list" endpoint '.
+            '(such as Packagist) cannot be mirrored.'
         );
     }
 

--- a/app/Domains/Mirror/Services/RegistryClient/V2RegistryClient.php
+++ b/app/Domains/Mirror/Services/RegistryClient/V2RegistryClient.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Domains\Mirror\Services\RegistryClient;
+
+use App\Domains\Mirror\Contracts\Interfaces\RegistryClientInterface;
+use Composer\MetadataMinifier\MetadataMinifier;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Str;
+
+class V2RegistryClient implements RegistryClientInterface
+{
+    /**
+     * @param  array<int, string>  $availablePackages
+     */
+    public function __construct(
+        protected PendingRequest $httpClient,
+        protected string $baseUrl,
+        protected string $metadataUrlTemplate,
+        protected array $availablePackages,
+    ) {}
+
+    public function getAvailablePackages(): array
+    {
+        return $this->availablePackages;
+    }
+
+    public function getPackageVersions(string $packageName): array
+    {
+        $versions = $this->fetchVersions($this->metadataUrl($packageName));
+
+        // Dev versions live in a separate "~dev" metadata file. A missing file
+        // is expected for packages without dev branches, so 404s are ignored.
+        $devVersions = $this->fetchVersions($this->metadataUrl($packageName.'~dev'));
+
+        return array_merge($versions, $devVersions);
+    }
+
+    public function validateConnection(): bool
+    {
+        return true;
+    }
+
+    public function downloadDist(string $url, string $outputPath): bool
+    {
+        $response = $this->httpClient->withOptions([
+            'sink' => $outputPath,
+        ])->get($url);
+
+        return $response->successful();
+    }
+
+    /**
+     * Fetch and expand the minified version metadata at the given URL.
+     *
+     * @return array<string, array<string, mixed>> version => composer.json data
+     */
+    protected function fetchVersions(string $url): array
+    {
+        $response = $this->httpClient->get($url);
+
+        if (! $response->successful()) {
+            return [];
+        }
+
+        $data = $response->json();
+
+        if (! is_array($data) || ! isset($data['packages']) || ! is_array($data['packages'])) {
+            return [];
+        }
+
+        $versions = [];
+
+        foreach ($data['packages'] as $minifiedVersions) {
+            if (! is_array($minifiedVersions)) {
+                continue;
+            }
+
+            foreach (MetadataMinifier::expand($minifiedVersions) as $composerJson) {
+                $version = (string) ($composerJson['version'] ?? '');
+
+                if ($version === '') {
+                    continue;
+                }
+
+                $versions[$version] = $composerJson;
+            }
+        }
+
+        return $versions;
+    }
+
+    /**
+     * Build the metadata URL for a package by resolving the metadata-url
+     * template against the registry base URL.
+     */
+    protected function metadataUrl(string $packageName): string
+    {
+        $path = str_replace('%package%', $packageName, $this->metadataUrlTemplate);
+
+        if (Str::startsWith($path, ['http://', 'https://'])) {
+            return $path;
+        }
+
+        return Str::finish($this->baseUrl, '/').ltrim($path, '/');
+    }
+}

--- a/tests/Feature/Domains/Mirror/SyncMirrorJobTest.php
+++ b/tests/Feature/Domains/Mirror/SyncMirrorJobTest.php
@@ -10,6 +10,7 @@ use App\Models\MirrorSyncLog;
 use App\Models\Organization;
 use App\Models\Package;
 use App\Models\PackageVersion;
+use Composer\MetadataMinifier\MetadataMinifier;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Http;
 
@@ -192,6 +193,33 @@ it('completes with empty sync when all versions are unchanged', function () {
     $syncLog = MirrorSyncLog::where('mirror_uuid', $this->mirror->uuid)->latest()->first();
     expect($syncLog->status)->toBe(SyncStatus::Success);
     expect($syncLog->versions_skipped)->toBe(1);
+});
+
+it('supports the Composer v2 metadata format', function () {
+    Bus::fake(SyncMirrorVersionJob::class);
+
+    Http::fake([
+        'satis.example.com/packages.json' => Http::response([
+            'metadata-url' => '/p2/%package%.json',
+            'available-packages' => ['vendor/pkg'],
+        ]),
+        'satis.example.com/p2/vendor/pkg.json' => Http::response([
+            'minified' => 'composer/2.0',
+            'packages' => [
+                'vendor/pkg' => MetadataMinifier::minify([
+                    ['name' => 'vendor/pkg', 'version' => '2.0.0', 'version_normalized' => '2.0.0.0', 'dist' => ['reference' => 'def']],
+                    ['name' => 'vendor/pkg', 'version' => '1.0.0', 'version_normalized' => '1.0.0.0', 'dist' => ['reference' => 'abc']],
+                ]),
+            ],
+        ]),
+        'satis.example.com/p2/vendor/pkg~dev.json' => Http::response('Not Found', 404),
+    ]);
+
+    SyncMirrorJob::dispatchSync($this->mirror);
+
+    $syncLog = MirrorSyncLog::where('mirror_uuid', $this->mirror->uuid)->latest()->first();
+    expect($syncLog->details['packages_found'])->toBe(1);
+    expect($syncLog->details['versions_found'])->toBe(2);
 });
 
 it('supports includes format in packages.json', function () {

--- a/tests/Feature/Domains/Mirror/V2RegistryClientTest.php
+++ b/tests/Feature/Domains/Mirror/V2RegistryClientTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use App\Domains\Mirror\Exceptions\MirrorSyncException;
+use App\Domains\Mirror\Services\RegistryClient\InlineRegistryClient;
+use App\Domains\Mirror\Services\RegistryClient\RegistryClientFactory;
+use App\Domains\Mirror\Services\RegistryClient\V2RegistryClient;
+use App\Models\Mirror;
+use App\Models\Organization;
+use Composer\MetadataMinifier\MetadataMinifier;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    $this->organization = Organization::factory()->create();
+    $this->mirror = Mirror::factory()->create([
+        'organization_uuid' => $this->organization->uuid,
+        'url' => 'https://registry.example.com',
+    ]);
+});
+
+/**
+ * Build a minified p2 metadata body, exactly as Pricore itself serves it.
+ *
+ * @param  array<int, array<string, mixed>>  $versions
+ */
+function fakeMetadataResponse(string $packageName, array $versions): array
+{
+    return [
+        'minified' => 'composer/2.0',
+        'packages' => [
+            $packageName => MetadataMinifier::minify($versions),
+        ],
+    ];
+}
+
+it('detects the Composer v2 format and prioritizes it over inline packages', function () {
+    Http::fake([
+        'registry.example.com/packages.json' => Http::response([
+            'metadata-url' => '/p2/%package%.json',
+            'available-packages' => ['vendor/pkg'],
+            // A stray v1 "packages" key must not take precedence.
+            'packages' => ['vendor/legacy' => []],
+        ]),
+    ]);
+
+    $client = RegistryClientFactory::make($this->mirror);
+
+    expect($client)->toBeInstanceOf(V2RegistryClient::class);
+    expect($client->getAvailablePackages())->toBe(['vendor/pkg']);
+});
+
+it('falls back to the inline v1 client when no metadata-url is present', function () {
+    Http::fake([
+        'registry.example.com/packages.json' => Http::response([
+            'packages' => [
+                'vendor/pkg' => [
+                    '1.0.0' => ['name' => 'vendor/pkg', 'version' => '1.0.0'],
+                ],
+            ],
+        ]),
+    ]);
+
+    expect(RegistryClientFactory::make($this->mirror))
+        ->toBeInstanceOf(InlineRegistryClient::class);
+});
+
+it('fetches and expands both stable and dev versions', function () {
+    Http::fake([
+        'registry.example.com/packages.json' => Http::response([
+            'metadata-url' => '/p2/%package%.json',
+            'available-packages' => ['vendor/pkg'],
+        ]),
+        'registry.example.com/p2/vendor/pkg.json' => Http::response(fakeMetadataResponse('vendor/pkg', [
+            ['name' => 'vendor/pkg', 'version' => '2.0.0', 'version_normalized' => '2.0.0.0', 'dist' => ['reference' => 'ref-2', 'url' => 'https://registry.example.com/d/2.zip']],
+            ['name' => 'vendor/pkg', 'version' => '1.0.0', 'version_normalized' => '1.0.0.0', 'dist' => ['reference' => 'ref-1', 'url' => 'https://registry.example.com/d/1.zip']],
+        ])),
+        'registry.example.com/p2/vendor/pkg~dev.json' => Http::response(fakeMetadataResponse('vendor/pkg', [
+            ['name' => 'vendor/pkg', 'version' => 'dev-main', 'version_normalized' => 'dev-main', 'dist' => ['reference' => 'ref-dev']],
+        ])),
+    ]);
+
+    $versions = RegistryClientFactory::make($this->mirror)->getPackageVersions('vendor/pkg');
+
+    expect(array_keys($versions))->toEqualCanonicalizing(['1.0.0', '2.0.0', 'dev-main']);
+    // Expansion must restore each version's own dist reference (not leak the diff).
+    expect($versions['2.0.0']['dist']['reference'])->toBe('ref-2');
+    expect($versions['1.0.0']['dist']['reference'])->toBe('ref-1');
+    expect($versions['dev-main']['dist']['reference'])->toBe('ref-dev');
+});
+
+it('ignores a missing dev metadata file', function () {
+    Http::fake([
+        'registry.example.com/packages.json' => Http::response([
+            'metadata-url' => '/p2/%package%.json',
+            'available-packages' => ['vendor/pkg'],
+        ]),
+        'registry.example.com/p2/vendor/pkg.json' => Http::response(fakeMetadataResponse('vendor/pkg', [
+            ['name' => 'vendor/pkg', 'version' => '1.0.0', 'version_normalized' => '1.0.0.0', 'dist' => ['reference' => 'ref-1']],
+        ])),
+        'registry.example.com/p2/vendor/pkg~dev.json' => Http::response('Not Found', 404),
+    ]);
+
+    $versions = RegistryClientFactory::make($this->mirror)->getPackageVersions('vendor/pkg');
+
+    expect(array_keys($versions))->toBe(['1.0.0']);
+});
+
+it('throws when a v2 registry does not advertise available-packages', function () {
+    Http::fake([
+        'registry.example.com/packages.json' => Http::response([
+            'metadata-url' => '/p2/%package%.json',
+            'list' => '/packages/list.json',
+        ]),
+    ]);
+
+    RegistryClientFactory::make($this->mirror);
+})->throws(MirrorSyncException::class, 'available-packages');


### PR DESCRIPTION
Closes #138

- Adds a `V2RegistryClient` that reads the Composer v2 `metadata-url` layout (fetching the per-package `p2/%package%.json` and `~dev` files and expanding the minified metadata), enabling mirroring another Pricore instance and v2-only registries like Private Packagist.
- `RegistryClientFactory` now detects and prioritizes v2, keeping the v1 inline/includes formats as fallbacks. Registries that only expose a `list` endpoint (e.g. full Packagist) fail with a clear, actionable error rather than attempting to enumerate everything.