### PR TITLE
feat(api): add REST API with scoped access tokens and OpenAPI docs

### DIFF
--- a/app/Domains/Activity/Contracts/Enums/ActivityType.php
+++ b/app/Domains/Activity/Contracts/Enums/ActivityType.php
@@ -18,6 +18,7 @@ enum ActivityType: string
     case MemberRoleChanged = 'member.role_changed';
     case InvitationSent = 'invitation.sent';
     case TokenCreated = 'token.created';
+    case TokenUpdated = 'token.updated';
     case TokenRevoked = 'token.revoked';
     case SshKeyGenerated = 'ssh_key.generated';
     case SshKeyDeleted = 'ssh_key.deleted';
@@ -41,6 +42,7 @@ enum ActivityType: string
             self::MemberRoleChanged => 'Role changed',
             self::InvitationSent => 'Invitation sent',
             self::TokenCreated => 'Token created',
+            self::TokenUpdated => 'Token updated',
             self::TokenRevoked => 'Token revoked',
             self::SshKeyGenerated => 'SSH key generated',
             self::SshKeyDeleted => 'SSH key deleted',
@@ -66,6 +68,7 @@ enum ActivityType: string
             self::MemberRoleChanged => 'shield',
             self::InvitationSent => 'mail',
             self::TokenCreated => 'key-round',
+            self::TokenUpdated => 'key-round',
             self::TokenRevoked => 'key-round',
             self::SshKeyGenerated => 'key-round',
             self::SshKeyDeleted => 'key-round',
@@ -83,7 +86,7 @@ enum ActivityType: string
             self::RepositoryAdded, self::RepositoryRemoved, self::RepositorySynced, self::RepositorySyncFailed => 'repository',
             self::PackageCreated, self::PackageRemoved => 'package',
             self::MemberAdded, self::MemberRemoved, self::MemberRoleChanged, self::InvitationSent => 'member',
-            self::TokenCreated, self::TokenRevoked => 'token',
+            self::TokenCreated, self::TokenUpdated, self::TokenRevoked => 'token',
             self::SshKeyGenerated, self::SshKeyDeleted => 'settings',
             self::MirrorAdded, self::MirrorRemoved, self::MirrorSynced, self::MirrorSyncFailed => 'mirror',
             self::VulnerabilitiesDetected => 'security',

--- a/app/Domains/Repository/Actions/CreateRepositoryAction.php
+++ b/app/Domains/Repository/Actions/CreateRepositoryAction.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Domains\Repository\Actions;
+
+use App\Domains\Activity\Actions\RecordActivityTask;
+use App\Domains\Activity\Contracts\Enums\ActivityType;
+use App\Domains\Repository\Contracts\Enums\GitProvider;
+use App\Domains\Repository\Jobs\SyncRepositoryJob;
+use App\Models\Organization;
+use App\Models\Repository;
+use App\Models\User;
+use App\Models\UserGitCredential;
+
+class CreateRepositoryAction
+{
+    public function __construct(
+        protected ExtractRepositoryNameAction $extractRepositoryName,
+        protected RegisterWebhookAction $registerWebhook,
+        protected RecordActivityTask $recordActivity,
+    ) {}
+
+    public function handle(
+        Organization $organization,
+        GitProvider $provider,
+        string $repoIdentifier,
+        User $user,
+        ?string $name = null,
+        ?string $defaultBranch = null,
+        ?string $sshKeyUuid = null,
+    ): Repository {
+        $name ??= $this->extractRepositoryName->handle($repoIdentifier, $provider);
+
+        $isGenericGit = $provider === GitProvider::Git;
+
+        $repository = Repository::create([
+            'organization_uuid' => $organization->uuid,
+            'credential_user_uuid' => $isGenericGit ? null : $user->uuid,
+            'ssh_key_uuid' => $isGenericGit ? $sshKeyUuid : null,
+            'name' => $name,
+            'provider' => $provider,
+            'repo_identifier' => $repoIdentifier,
+            'custom_base_url' => $this->resolveBaseUrl($provider, $user->uuid),
+            'default_branch' => $defaultBranch,
+        ]);
+
+        $this->recordActivity->handle(
+            organization: $organization,
+            type: ActivityType::RepositoryAdded,
+            subject: $repository,
+            actor: $user,
+            properties: ['name' => $repository->name, 'provider' => $repository->provider->value],
+        );
+
+        SyncRepositoryJob::dispatch($repository);
+
+        $this->registerWebhook->handle($repository);
+
+        return $repository;
+    }
+
+    private function resolveBaseUrl(GitProvider $provider, string $userUuid): ?string
+    {
+        if (! $provider->supportsSelfHosted()) {
+            return null;
+        }
+
+        $credential = UserGitCredential::query()
+            ->where('user_uuid', $userUuid)
+            ->where('provider', $provider)
+            ->first();
+
+        return $credential?->credentials['url'] ?? null;
+    }
+}

--- a/app/Domains/Repository/Http/Controllers/RepositoryController.php
+++ b/app/Domains/Repository/Http/Controllers/RepositoryController.php
@@ -8,20 +8,17 @@ use App\Domains\Organization\Contracts\Data\OrganizationData;
 use App\Domains\Organization\Contracts\Data\OrganizationSshKeyData;
 use App\Domains\Package\Contracts\Data\PackageData;
 use App\Domains\Repository\Actions\BulkCreateRepositoriesAction;
+use App\Domains\Repository\Actions\CreateRepositoryAction;
 use App\Domains\Repository\Actions\DeleteWebhookAction;
-use App\Domains\Repository\Actions\ExtractRepositoryNameAction;
-use App\Domains\Repository\Actions\RegisterWebhookAction;
 use App\Domains\Repository\Contracts\Data\RepositoryData;
 use App\Domains\Repository\Contracts\Data\SyncLogData;
 use App\Domains\Repository\Contracts\Enums\GitProvider;
 use App\Domains\Repository\Http\Requests\BulkStoreRepositoryRequest;
 use App\Domains\Repository\Http\Requests\StoreRepositoryRequest;
-use App\Domains\Repository\Jobs\SyncRepositoryJob;
 use App\Http\Controllers\Controller;
 use App\Models\Organization;
 use App\Models\Repository;
 use App\Models\User;
-use App\Models\UserGitCredential;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -33,8 +30,6 @@ class RepositoryController extends Controller
     use AuthorizesRequests;
 
     public function __construct(
-        protected ExtractRepositoryNameAction $extractRepositoryNameAction,
-        protected RegisterWebhookAction $registerWebhookAction,
         protected DeleteWebhookAction $deleteWebhookAction,
         protected RecordActivityTask $recordActivity,
     ) {}
@@ -70,49 +65,25 @@ class RepositoryController extends Controller
         ]);
     }
 
-    public function store(StoreRepositoryRequest $request, Organization $organization): RedirectResponse
+    public function store(StoreRepositoryRequest $request, Organization $organization, CreateRepositoryAction $createRepository): RedirectResponse
     {
         $this->authorize('deleteRepository', $organization);
-
-        $name = $request->name ?? $this->extractRepositoryNameAction->handle(
-            $request->repo_identifier,
-            GitProvider::from($request->provider)
-        );
-
-        $provider = GitProvider::from($request->provider);
 
         /** @var User $user */
         $user = auth()->user();
 
-        $baseUrl = $this->resolveBaseUrl($provider, $user->uuid);
-
-        $isGenericGit = $provider === GitProvider::Git;
-
-        $repository = Repository::create([
-            'organization_uuid' => $organization->uuid,
-            'credential_user_uuid' => $isGenericGit ? null : $user->uuid,
-            'ssh_key_uuid' => $isGenericGit ? $request->ssh_key_uuid : null,
-            'name' => $name,
-            'provider' => $provider,
-            'repo_identifier' => $request->repo_identifier,
-            'custom_base_url' => $baseUrl,
-            'default_branch' => $request->default_branch,
-        ]);
-
-        $this->recordActivity->handle(
+        $repository = $createRepository->handle(
             organization: $organization,
-            type: ActivityType::RepositoryAdded,
-            subject: $repository,
-            actor: $request->user(),
-            properties: ['name' => $repository->name, 'provider' => $repository->provider->value],
+            provider: GitProvider::from($request->provider),
+            repoIdentifier: $request->repo_identifier,
+            user: $user,
+            name: $request->name,
+            defaultBranch: $request->default_branch,
+            sshKeyUuid: $request->ssh_key_uuid,
         );
 
-        SyncRepositoryJob::dispatch($repository);
-
-        $webhookRegistered = $this->registerWebhookAction->handle($repository);
-
         $message = 'Repository added successfully.';
-        if (! $webhookRegistered && $repository->provider->supportsAutomaticWebhooks()) {
+        if ($repository->webhook_id === null && $repository->provider->supportsAutomaticWebhooks()) {
             $message .= ' Webhook registration failed — you can retry from the repository page.';
         }
 
@@ -222,19 +193,5 @@ class RepositoryController extends Controller
         return redirect()
             ->route('organizations.repositories.index', $organization)
             ->with('status', 'Repository deleted successfully.');
-    }
-
-    private function resolveBaseUrl(GitProvider $provider, string $userUuid): ?string
-    {
-        if (! $provider->supportsSelfHosted()) {
-            return null;
-        }
-
-        $credential = UserGitCredential::query()
-            ->where('user_uuid', $userUuid)
-            ->where('provider', $provider)
-            ->first();
-
-        return $credential?->credentials['url'] ?? null;
     }
 }

--- a/app/Domains/Token/Actions/CreateAccessTokenAction.php
+++ b/app/Domains/Token/Actions/CreateAccessTokenAction.php
@@ -5,6 +5,7 @@ namespace App\Domains\Token\Actions;
 use App\Domains\Activity\Actions\RecordActivityTask;
 use App\Domains\Activity\Contracts\Enums\ActivityType;
 use App\Domains\Token\Contracts\Data\TokenCreatedData;
+use App\Domains\Token\Contracts\Enums\TokenScope;
 use App\Models\AccessToken;
 use App\Models\Organization;
 use App\Models\User;
@@ -17,11 +18,15 @@ class CreateAccessTokenAction
         protected RecordActivityTask $recordActivity,
     ) {}
 
+    /**
+     * @param  array<int, TokenScope|string>|null  $scopes  Null grants full (legacy) access.
+     */
     public function handle(
         ?Organization $organization,
         ?User $user,
         string $name,
-        ?Carbon $expiresAt = null
+        ?Carbon $expiresAt = null,
+        ?array $scopes = null,
     ): TokenCreatedData {
         $plainToken = Str::random(64);
         $tokenHash = hash('sha256', $plainToken);
@@ -32,6 +37,7 @@ class CreateAccessTokenAction
             'name' => $name,
             'token_hash' => $tokenHash,
             'expires_at' => $expiresAt,
+            'scopes' => $scopes !== null ? TokenScope::normalize($scopes) : null,
         ]);
 
         if ($organization) {
@@ -49,6 +55,7 @@ class CreateAccessTokenAction
             name: $name,
             expiresAt: $accessToken->expires_at,
             organizationUuid: $accessToken->organization_uuid,
+            scopes: $accessToken->scopes ?? [],
         );
     }
 }

--- a/app/Domains/Token/Actions/UpdateAccessTokenAction.php
+++ b/app/Domains/Token/Actions/UpdateAccessTokenAction.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Domains\Token\Actions;
+
+use App\Domains\Activity\Actions\RecordActivityTask;
+use App\Domains\Activity\Contracts\Enums\ActivityType;
+use App\Domains\Token\Contracts\Enums\TokenScope;
+use App\Models\AccessToken;
+use App\Models\User;
+
+class UpdateAccessTokenAction
+{
+    public function __construct(
+        protected RecordActivityTask $recordActivity,
+    ) {}
+
+    /**
+     * Update a token's name and (optionally) its scopes. A null $scopes leaves
+     * the existing scopes untouched; an array replaces them.
+     *
+     * @param  array<int, TokenScope|string>|null  $scopes
+     */
+    public function handle(AccessToken $accessToken, string $name, ?array $scopes = null, ?User $actor = null): AccessToken
+    {
+        $attributes = ['name' => $name];
+
+        if ($scopes !== null) {
+            $attributes['scopes'] = TokenScope::normalize($scopes);
+        }
+
+        $accessToken->update($attributes);
+
+        if ($accessToken->organization) {
+            $this->recordActivity->handle(
+                organization: $accessToken->organization,
+                type: ActivityType::TokenUpdated,
+                subject: $accessToken,
+                actor: $actor ?? auth()->user(),
+                properties: ['name' => $accessToken->name],
+            );
+        }
+
+        return $accessToken;
+    }
+}

--- a/app/Domains/Token/Contracts/Data/AccessTokenData.php
+++ b/app/Domains/Token/Contracts/Data/AccessTokenData.php
@@ -10,12 +10,16 @@ use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 #[TypeScript]
 class AccessTokenData extends Data
 {
+    /**
+     * @param  array<int, string>  $scopes
+     */
     public function __construct(
         public string $uuid,
         public string $name,
         public ?CarbonInterface $lastUsedAt,
         public ?CarbonInterface $expiresAt,
         public CarbonInterface $createdAt,
+        public array $scopes = [],
     ) {}
 
     public static function fromModel(AccessToken $token): self
@@ -32,6 +36,7 @@ class AccessTokenData extends Data
             lastUsedAt: $token->last_used_at,
             expiresAt: $token->expires_at,
             createdAt: $createdAt,
+            scopes: $token->scopes ?? [],
         );
     }
 }

--- a/app/Domains/Token/Contracts/Data/TokenCreatedData.php
+++ b/app/Domains/Token/Contracts/Data/TokenCreatedData.php
@@ -9,10 +9,14 @@ use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 #[TypeScript]
 class TokenCreatedData extends Data
 {
+    /**
+     * @param  array<int, string>  $scopes
+     */
     public function __construct(
         public string $plainToken,
         public string $name,
         public ?CarbonInterface $expiresAt,
         public ?string $organizationUuid,
+        public array $scopes = [],
     ) {}
 }

--- a/app/Domains/Token/Contracts/Enums/TokenScope.php
+++ b/app/Domains/Token/Contracts/Enums/TokenScope.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Domains\Token\Contracts\Enums;
+
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+enum TokenScope: string
+{
+    // Composer registry access (what legacy and org tokens do today).
+    case Composer = 'composer';
+
+    case ReadOrganizations = 'read:organizations';
+    case WriteOrganizations = 'write:organizations';
+    case DeleteOrganizations = 'delete:organizations';
+
+    case ReadRepositories = 'read:repositories';
+    case WriteRepositories = 'write:repositories';
+    case DeleteRepositories = 'delete:repositories';
+
+    case ReadPackages = 'read:packages';
+    case WritePackages = 'write:packages';
+    case DeletePackages = 'delete:packages';
+
+    case ReadMembers = 'read:members';
+    case WriteMembers = 'write:members';
+
+    case ReadMirrors = 'read:mirrors';
+    case WriteMirrors = 'write:mirrors';
+    case DeleteMirrors = 'delete:mirrors';
+
+    case ReadTokens = 'read:tokens';
+    case WriteTokens = 'write:tokens';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Composer => 'Composer registry access',
+            self::ReadOrganizations => 'Read organizations',
+            self::WriteOrganizations => 'Create & update organizations',
+            self::DeleteOrganizations => 'Delete organizations',
+            self::ReadRepositories => 'Read repositories',
+            self::WriteRepositories => 'Add & sync repositories',
+            self::DeleteRepositories => 'Delete repositories',
+            self::ReadPackages => 'Read packages',
+            self::WritePackages => 'Manage packages',
+            self::DeletePackages => 'Delete packages & versions',
+            self::ReadMembers => 'Read members & invitations',
+            self::WriteMembers => 'Manage members & invitations',
+            self::ReadMirrors => 'Read mirrors',
+            self::WriteMirrors => 'Add & sync mirrors',
+            self::DeleteMirrors => 'Delete mirrors',
+            self::ReadTokens => 'Read access tokens',
+            self::WriteTokens => 'Create & revoke access tokens',
+        };
+    }
+
+    /**
+     * The resource group this scope belongs to (used to group scopes in the UI).
+     */
+    public function resource(): string
+    {
+        return match ($this) {
+            self::Composer => 'composer',
+            self::ReadOrganizations, self::WriteOrganizations, self::DeleteOrganizations => 'organizations',
+            self::ReadRepositories, self::WriteRepositories, self::DeleteRepositories => 'repositories',
+            self::ReadPackages, self::WritePackages, self::DeletePackages => 'packages',
+            self::ReadMembers, self::WriteMembers => 'members',
+            self::ReadMirrors, self::WriteMirrors, self::DeleteMirrors => 'mirrors',
+            self::ReadTokens, self::WriteTokens => 'tokens',
+        };
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function options(): array
+    {
+        $options = [];
+
+        foreach (self::cases() as $scope) {
+            $options[$scope->value] = $scope->label();
+        }
+
+        return $options;
+    }
+
+    /**
+     * Scopes grouped by resource for grouped UI rendering.
+     *
+     * @return array<string, array<string, string>>
+     */
+    public static function grouped(): array
+    {
+        $grouped = [];
+
+        foreach (self::cases() as $scope) {
+            $grouped[$scope->resource()][$scope->value] = $scope->label();
+        }
+
+        return $grouped;
+    }
+
+    /**
+     * Default scopes for a token used purely for Composer registry access.
+     *
+     * @return array<int, self>
+     */
+    public static function composerDefault(): array
+    {
+        return [self::Composer];
+    }
+
+    /**
+     * Normalize a mixed list of scopes into a deduplicated list of string values.
+     *
+     * @param  array<int, self|string>  $scopes
+     * @return array<int, string>
+     */
+    public static function normalize(array $scopes): array
+    {
+        return array_values(array_unique(array_map(
+            fn (self|string $scope) => $scope instanceof self ? $scope->value : $scope,
+            $scopes,
+        )));
+    }
+}

--- a/app/Domains/Token/Http/Controllers/TokenController.php
+++ b/app/Domains/Token/Http/Controllers/TokenController.php
@@ -6,8 +6,11 @@ use App\Domains\Activity\Actions\RecordActivityTask;
 use App\Domains\Activity\Contracts\Enums\ActivityType;
 use App\Domains\Organization\Contracts\Data\OrganizationData;
 use App\Domains\Token\Actions\CreateAccessTokenAction;
+use App\Domains\Token\Actions\UpdateAccessTokenAction;
 use App\Domains\Token\Contracts\Data\AccessTokenData;
+use App\Domains\Token\Contracts\Enums\TokenScope;
 use App\Domains\Token\Requests\StoreAccessTokenRequest;
+use App\Domains\Token\Requests\UpdateAccessTokenRequest;
 use App\Http\Controllers\Controller;
 use App\Models\AccessToken;
 use App\Models\Organization;
@@ -22,6 +25,7 @@ class TokenController extends Controller
 
     public function __construct(
         protected CreateAccessTokenAction $createAccessToken,
+        protected UpdateAccessTokenAction $updateAccessToken,
         protected RecordActivityTask $recordActivity,
     ) {}
 
@@ -49,7 +53,8 @@ class TokenController extends Controller
             organization: $organization,
             user: null,
             name: $request->validated('name'),
-            expiresAt: $request->validated('expires_at') ? now()->parse($request->validated('expires_at')) : null
+            expiresAt: $request->validated('expires_at') ? now()->parse($request->validated('expires_at')) : null,
+            scopes: $request->validated('scopes') ?? [TokenScope::Composer->value],
         );
 
         $tokens = AccessToken::query()
@@ -63,6 +68,25 @@ class TokenController extends Controller
             'tokens' => $tokens,
             'tokenCreated' => $result,
         ]);
+    }
+
+    public function update(UpdateAccessTokenRequest $request, Organization $organization, AccessToken $token): RedirectResponse
+    {
+        $this->authorize('viewSettings', $organization);
+
+        if ($token->organization_uuid !== $organization->uuid) {
+            abort(403);
+        }
+
+        $this->updateAccessToken->handle(
+            accessToken: $token,
+            name: $request->validated('name'),
+            scopes: $request->validated('scopes'),
+            actor: $request->user(),
+        );
+
+        return to_route('organizations.settings.tokens.index', $organization)
+            ->with('status', 'Token updated successfully.');
     }
 
     public function destroy(Organization $organization, AccessToken $token): RedirectResponse

--- a/app/Domains/Token/Http/Controllers/UserTokenController.php
+++ b/app/Domains/Token/Http/Controllers/UserTokenController.php
@@ -3,8 +3,11 @@
 namespace App\Domains\Token\Http\Controllers;
 
 use App\Domains\Token\Actions\CreateAccessTokenAction;
+use App\Domains\Token\Actions\UpdateAccessTokenAction;
 use App\Domains\Token\Contracts\Data\AccessTokenData;
+use App\Domains\Token\Contracts\Enums\TokenScope;
 use App\Domains\Token\Requests\StoreAccessTokenRequest;
+use App\Domains\Token\Requests\UpdateAccessTokenRequest;
 use App\Http\Controllers\Controller;
 use App\Models\AccessToken;
 use App\Models\User;
@@ -16,7 +19,8 @@ use Inertia\Response;
 class UserTokenController extends Controller
 {
     public function __construct(
-        protected CreateAccessTokenAction $createAccessToken
+        protected CreateAccessTokenAction $createAccessToken,
+        protected UpdateAccessTokenAction $updateAccessToken,
     ) {}
 
     public function index(Request $request): Response
@@ -44,7 +48,8 @@ class UserTokenController extends Controller
             organization: null,
             user: $user,
             name: $request->validated('name'),
-            expiresAt: $request->validated('expires_at') ? now()->parse($request->validated('expires_at')) : null
+            expiresAt: $request->validated('expires_at') ? now()->parse($request->validated('expires_at')) : null,
+            scopes: $request->validated('scopes') ?? [TokenScope::Composer->value],
         );
 
         $tokens = AccessToken::query()
@@ -57,6 +62,26 @@ class UserTokenController extends Controller
             'tokens' => $tokens,
             'tokenCreated' => $result,
         ]);
+    }
+
+    public function update(UpdateAccessTokenRequest $request, AccessToken $token): RedirectResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        if ($token->user_uuid !== $user->uuid) {
+            abort(403);
+        }
+
+        $this->updateAccessToken->handle(
+            accessToken: $token,
+            name: $request->validated('name'),
+            scopes: $request->validated('scopes'),
+            actor: $user,
+        );
+
+        return to_route('settings.tokens.index')
+            ->with('status', 'Token updated successfully.');
     }
 
     public function destroy(Request $request, AccessToken $token): RedirectResponse

--- a/app/Domains/Token/Requests/StoreAccessTokenRequest.php
+++ b/app/Domains/Token/Requests/StoreAccessTokenRequest.php
@@ -2,8 +2,10 @@
 
 namespace App\Domains\Token\Requests;
 
+use App\Domains\Token\Contracts\Enums\TokenScope;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreAccessTokenRequest extends FormRequest
 {
@@ -15,6 +17,8 @@ class StoreAccessTokenRequest extends FormRequest
         return [
             'name' => ['required', 'string', 'max:255'],
             'expires_at' => ['nullable', 'string'],
+            'scopes' => ['nullable', 'array'],
+            'scopes.*' => [Rule::enum(TokenScope::class)],
         ];
     }
 

--- a/app/Domains/Token/Requests/UpdateAccessTokenRequest.php
+++ b/app/Domains/Token/Requests/UpdateAccessTokenRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Domains\Token\Requests;
+
+use App\Domains\Token\Contracts\Enums\TokenScope;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateAccessTokenRequest extends FormRequest
+{
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'scopes' => ['nullable', 'array'],
+            'scopes.*' => [Rule::enum(TokenScope::class)],
+        ];
+    }
+}

--- a/app/Domains/Token/Services/AccessTokenResolver.php
+++ b/app/Domains/Token/Services/AccessTokenResolver.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Domains\Token\Services;
+
+use App\Models\AccessToken;
+use Illuminate\Http\Request;
+
+class AccessTokenResolver
+{
+    /**
+     * Resolve the access token from the request's Authorization header, if any.
+     */
+    public function fromRequest(Request $request): ?AccessToken
+    {
+        $token = $this->extractToken($request);
+
+        if (! $token) {
+            return null;
+        }
+
+        return $this->findAccessToken($token);
+    }
+
+    /**
+     * Extract the plaintext token from a Bearer or Basic Authorization header.
+     */
+    public function extractToken(Request $request): ?string
+    {
+        $header = $request->header('Authorization');
+
+        if (! $header) {
+            return null;
+        }
+
+        // Bearer token
+        if (preg_match('/^Bearer\s+(.+)$/i', $header, $matches)) {
+            return $matches[1];
+        }
+
+        // Basic auth (token as password, username is ignored)
+        if (preg_match('/^Basic\s+(.+)$/i', $header, $matches)) {
+            $decoded = base64_decode($matches[1], true);
+            if ($decoded === false) {
+                return null;
+            }
+
+            // Basic auth format: username:password — the token is in the password field.
+            $parts = explode(':', $decoded, 2);
+
+            return $parts[1] ?? null;
+        }
+
+        return null;
+    }
+
+    public function findAccessToken(string $token): ?AccessToken
+    {
+        $tokenHash = hash('sha256', $token);
+
+        return AccessToken::query()
+            ->where('token_hash', $tokenHash)
+            ->with(['organization', 'user'])
+            ->first();
+    }
+}

--- a/app/Domains/Token/Services/TokenScopeChecker.php
+++ b/app/Domains/Token/Services/TokenScopeChecker.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Domains\Token\Services;
+
+use App\Domains\Token\Contracts\Enums\TokenScope;
+use App\Models\AccessToken;
+
+class TokenScopeChecker
+{
+    /**
+     * Determine whether the token carries the given scope.
+     *
+     * A null `scopes` value means the token predates scope support and is
+     * treated as having full access (backward compatible). An explicit empty
+     * array grants nothing.
+     */
+    public function hasScope(AccessToken $token, TokenScope $scope): bool
+    {
+        if ($token->scopes === null) {
+            return true;
+        }
+
+        return in_array($scope->value, $token->scopes, true);
+    }
+
+    /**
+     * Determine whether the token carries any of the given scopes.
+     */
+    public function hasAny(AccessToken $token, TokenScope ...$scopes): bool
+    {
+        foreach ($scopes as $scope) {
+            if ($this->hasScope($token, $scope)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/Http/Controllers/Api/V1/ApiController.php
+++ b/app/Http/Controllers/Api/V1/ApiController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\AccessToken;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\Request;
+
+abstract class ApiController extends Controller
+{
+    use AuthorizesRequests;
+
+    /**
+     * The access token authenticating the current request.
+     */
+    protected function accessToken(Request $request): AccessToken
+    {
+        $accessToken = $request->get('accessToken');
+
+        abort_unless($accessToken instanceof AccessToken, 401);
+
+        return $accessToken;
+    }
+
+    /**
+     * Ensure the request is authenticated with a personal (user) access token,
+     * not an organization-scoped token.
+     */
+    protected function requirePersonalAccessToken(Request $request): void
+    {
+        abort_if(
+            $this->accessToken($request)->organization_uuid !== null,
+            403,
+            'This endpoint requires a personal access token.',
+        );
+    }
+
+    /**
+     * Resolve the requested page size, clamped to a sensible range.
+     */
+    protected function perPage(Request $request): int
+    {
+        return min(max($request->integer('per_page', 25), 1), 100);
+    }
+}

--- a/app/Http/Controllers/Api/V1/InvitationController.php
+++ b/app/Http/Controllers/Api/V1/InvitationController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Domains\Organization\Actions\ResendOrganizationInvitationAction;
+use App\Domains\Organization\Contracts\Data\OrganizationInvitationData;
+use App\Models\Organization;
+use App\Models\OrganizationInvitation;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Spatie\LaravelData\PaginatedDataCollection;
+
+class InvitationController extends ApiController
+{
+    /**
+     * @return PaginatedDataCollection<array-key, OrganizationInvitationData>
+     */
+    public function index(Request $request, Organization $organization): PaginatedDataCollection
+    {
+        $this->authorize('viewSettings', $organization);
+
+        $invitations = $organization->invitations()
+            ->orderBy('created_at', 'desc')
+            ->paginate($this->perPage($request))
+            ->through(fn ($invitation) => OrganizationInvitationData::fromModel($invitation));
+
+        return OrganizationInvitationData::collect($invitations, PaginatedDataCollection::class);
+    }
+
+    public function resend(Organization $organization, OrganizationInvitation $invitation, ResendOrganizationInvitationAction $resend): OrganizationInvitationData
+    {
+        $this->authorize('manageMembers', $organization);
+        abort_unless($invitation->organization_uuid === $organization->uuid, 404);
+        abort_if($invitation->isAccepted(), 422, 'This invitation has already been accepted.');
+
+        $resend->handle($invitation);
+
+        return OrganizationInvitationData::fromModel($invitation->refresh());
+    }
+
+    public function destroy(Organization $organization, OrganizationInvitation $invitation): Response
+    {
+        $this->authorize('manageMembers', $organization);
+        abort_unless($invitation->organization_uuid === $organization->uuid, 404);
+
+        $invitation->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Api/V1/MemberController.php
+++ b/app/Http/Controllers/Api/V1/MemberController.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Domains\Activity\Actions\RecordActivityTask;
+use App\Domains\Activity\Contracts\Enums\ActivityType;
+use App\Domains\Organization\Actions\SendOrganizationInvitationAction;
+use App\Domains\Organization\Contracts\Data\OrganizationInvitationData;
+use App\Domains\Organization\Contracts\Data\OrganizationMemberData;
+use App\Domains\Organization\Contracts\Enums\OrganizationRole;
+use App\Domains\Organization\Requests\AddMemberRequest;
+use App\Domains\Organization\Requests\UpdateMemberRoleRequest;
+use App\Models\Organization;
+use App\Models\OrganizationUser;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Spatie\LaravelData\PaginatedDataCollection;
+
+class MemberController extends ApiController
+{
+    /**
+     * @return PaginatedDataCollection<array-key, OrganizationMemberData>
+     */
+    public function index(Request $request, Organization $organization): PaginatedDataCollection
+    {
+        $this->authorize('viewSettings', $organization);
+
+        $members = $organization->members()
+            ->orderBy('name')
+            ->paginate($this->perPage($request))
+            ->through(fn (User $user) => OrganizationMemberData::fromUserAndPivot($user, $user->pivot));
+
+        return OrganizationMemberData::collect($members, PaginatedDataCollection::class);
+    }
+
+    public function store(AddMemberRequest $request, Organization $organization, SendOrganizationInvitationAction $sendInvitation): OrganizationInvitationData
+    {
+        $this->authorize('manageMembers', $organization);
+
+        $email = $request->validated('email');
+        $role = OrganizationRole::from($request->validated('role'));
+
+        $existingUser = User::where('email', $email)->first();
+        if ($existingUser && $organization->members()->where('user_uuid', $existingUser->uuid)->exists()) {
+            abort(422, 'User is already a member of this organization.');
+        }
+
+        if ($organization->pendingInvitations()->where('email', $email)->exists()) {
+            abort(422, 'An invitation has already been sent to this email address.');
+        }
+
+        /** @var User $invitedBy */
+        $invitedBy = $request->user();
+
+        $invitation = $sendInvitation->handle($organization, $email, $role, $invitedBy);
+
+        return OrganizationInvitationData::fromModel($invitation);
+    }
+
+    public function update(UpdateMemberRoleRequest $request, Organization $organization, OrganizationUser $member, RecordActivityTask $recordActivity): OrganizationMemberData
+    {
+        $this->authorize('manageMembers', $organization);
+        abort_unless($member->organization_uuid === $organization->uuid, 404);
+        abort_if($member->role->isOwner(), 422, 'Cannot change the role of the organization owner.');
+
+        $oldRole = $member->role->value;
+        $member->update(['role' => $request->validated('role')]);
+
+        $memberUser = $member->user;
+
+        $recordActivity->handle(
+            organization: $organization,
+            type: ActivityType::MemberRoleChanged,
+            subject: $memberUser,
+            actor: $request->user(),
+            properties: [
+                'member_name' => $memberUser->name,
+                'old_role' => $oldRole,
+                'new_role' => $request->validated('role'),
+            ],
+        );
+
+        return new OrganizationMemberData(
+            uuid: $member->uuid,
+            name: $memberUser->name,
+            email: $memberUser->email,
+            avatar: $memberUser->avatar,
+            role: $member->role,
+            joinedAt: $member->created_at,
+        );
+    }
+
+    public function destroy(Request $request, Organization $organization, OrganizationUser $member, RecordActivityTask $recordActivity): Response
+    {
+        $this->authorize('manageMembers', $organization);
+        abort_unless($member->organization_uuid === $organization->uuid, 404);
+        abort_if($member->role->isOwner(), 422, 'Cannot remove the organization owner.');
+
+        $memberUser = $member->user;
+
+        $recordActivity->handle(
+            organization: $organization,
+            type: ActivityType::MemberRemoved,
+            subject: $memberUser,
+            actor: $request->user(),
+            properties: [
+                'member_name' => $memberUser->name,
+                'member_email' => $memberUser->email,
+            ],
+        );
+
+        $member->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Api/V1/MirrorController.php
+++ b/app/Http/Controllers/Api/V1/MirrorController.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Domains\Activity\Actions\RecordActivityTask;
+use App\Domains\Activity\Contracts\Enums\ActivityType;
+use App\Domains\Mirror\Contracts\Data\MirrorData;
+use App\Domains\Mirror\Http\Requests\StoreMirrorRequest;
+use App\Domains\Mirror\Jobs\SyncMirrorJob;
+use App\Domains\Repository\Contracts\Enums\RepositorySyncStatus;
+use App\Models\Mirror;
+use App\Models\Organization;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Spatie\LaravelData\PaginatedDataCollection;
+
+class MirrorController extends ApiController
+{
+    public function __construct(
+        protected RecordActivityTask $recordActivity,
+    ) {}
+
+    /**
+     * @return PaginatedDataCollection<array-key, MirrorData>
+     */
+    public function index(Request $request, Organization $organization): PaginatedDataCollection
+    {
+        $this->authorize('viewSettings', $organization);
+
+        $mirrors = $organization->mirrors()
+            ->withCount('packages')
+            ->orderBy('name')
+            ->paginate($this->perPage($request))
+            ->through(fn ($mirror) => MirrorData::fromModel($mirror));
+
+        return MirrorData::collect($mirrors, PaginatedDataCollection::class);
+    }
+
+    public function store(StoreMirrorRequest $request, Organization $organization): MirrorData
+    {
+        $this->authorize('viewSettings', $organization);
+
+        $mirror = $organization->mirrors()->create([
+            'name' => $request->validated('name'),
+            'url' => $request->validated('url'),
+            'auth_type' => $request->validated('auth_type'),
+            'auth_credentials' => $request->authCredentials(),
+            'mirror_dist' => $request->validated('mirror_dist', true),
+            'sync_status' => RepositorySyncStatus::Pending,
+        ]);
+
+        $this->recordActivity->handle(
+            organization: $organization,
+            type: ActivityType::MirrorAdded,
+            subject: $mirror,
+            actor: $request->user(),
+            properties: ['name' => $mirror->name],
+        );
+
+        SyncMirrorJob::dispatch($mirror);
+
+        return MirrorData::fromModel($mirror->loadCount('packages'));
+    }
+
+    public function show(Organization $organization, Mirror $mirror): MirrorData
+    {
+        $this->authorize('viewSettings', $organization);
+        $this->ensureBelongsToOrganization($organization, $mirror);
+
+        return MirrorData::fromModel($mirror->loadCount('packages'));
+    }
+
+    public function sync(Organization $organization, Mirror $mirror): MirrorData
+    {
+        $this->authorize('viewSettings', $organization);
+        $this->ensureBelongsToOrganization($organization, $mirror);
+
+        $mirror->update(['sync_status' => RepositorySyncStatus::Pending]);
+
+        SyncMirrorJob::dispatch($mirror);
+
+        return MirrorData::fromModel($mirror->loadCount('packages'));
+    }
+
+    public function destroy(Request $request, Organization $organization, Mirror $mirror): Response
+    {
+        $this->authorize('viewSettings', $organization);
+        $this->ensureBelongsToOrganization($organization, $mirror);
+
+        $this->recordActivity->handle(
+            organization: $organization,
+            type: ActivityType::MirrorRemoved,
+            subject: $mirror,
+            actor: $request->user(),
+            properties: ['name' => $mirror->name],
+        );
+
+        $mirror->delete();
+
+        return response()->noContent();
+    }
+
+    private function ensureBelongsToOrganization(Organization $organization, Mirror $mirror): void
+    {
+        abort_unless($mirror->organization_uuid === $organization->uuid, 404);
+    }
+}

--- a/app/Http/Controllers/Api/V1/OrganizationController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Domains\Organization\Actions\CreateOrganizationAction;
+use App\Domains\Organization\Contracts\Data\OrganizationData;
+use App\Domains\Organization\Requests\StoreOrganizationRequest;
+use App\Domains\Organization\Requests\UpdateOrganizationRequest;
+use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Spatie\LaravelData\PaginatedDataCollection;
+
+class OrganizationController extends ApiController
+{
+    /**
+     * List organizations accessible to the authenticated token.
+     *
+     * @return PaginatedDataCollection<array-key, OrganizationData>
+     */
+    public function index(Request $request): PaginatedDataCollection
+    {
+        $accessToken = $this->accessToken($request);
+
+        if ($accessToken->organization_uuid !== null) {
+            // An organization-scoped token can only ever see its own organization.
+            $query = Organization::query()->whereKey($accessToken->organization_uuid);
+        } else {
+            /** @var User $user */
+            $user = $request->user();
+            $query = $user->organizations()->getQuery();
+        }
+
+        $organizations = $query
+            ->orderBy('name')
+            ->paginate($this->perPage($request))
+            ->through(fn ($organization) => OrganizationData::fromModel($organization));
+
+        return OrganizationData::collect($organizations, PaginatedDataCollection::class);
+    }
+
+    /**
+     * Create a new organization owned by the authenticated user.
+     */
+    public function store(StoreOrganizationRequest $request, CreateOrganizationAction $createOrganization): OrganizationData
+    {
+        $this->requirePersonalAccessToken($request);
+
+        /** @var User $user */
+        $user = $request->user();
+
+        return $createOrganization->handle(
+            name: $request->validated('name'),
+            ownerUuid: $user->uuid,
+        );
+    }
+
+    public function show(Request $request, Organization $organization): OrganizationData
+    {
+        $this->authorize('view', $organization);
+
+        return OrganizationData::fromModel($organization);
+    }
+
+    public function update(UpdateOrganizationRequest $request, Organization $organization): OrganizationData
+    {
+        $user = $request->user();
+        $isOwner = $user !== null && $organization->owner_uuid === $user->uuid;
+
+        $attributes = ['name' => $request->validated('name')];
+
+        if ($isOwner && $request->has('slug')) {
+            $attributes['slug'] = $request->validated('slug');
+        }
+
+        $organization->update($attributes);
+
+        return OrganizationData::fromModel($organization->refresh());
+    }
+
+    public function destroy(Request $request, Organization $organization): Response
+    {
+        $this->authorize('delete', $organization);
+
+        $organization->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Api/V1/PackageController.php
+++ b/app/Http/Controllers/Api/V1/PackageController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Domains\Activity\Actions\RecordActivityTask;
+use App\Domains\Activity\Contracts\Enums\ActivityType;
+use App\Domains\Package\Contracts\Data\PackageData;
+use App\Models\Organization;
+use App\Models\Package;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Spatie\LaravelData\PaginatedDataCollection;
+
+class PackageController extends ApiController
+{
+    /**
+     * @return PaginatedDataCollection<array-key, PackageData>
+     */
+    public function index(Request $request, Organization $organization): PaginatedDataCollection
+    {
+        $this->authorize('view', $organization);
+
+        $packages = $organization->packages()
+            ->with(['repository', 'mirror'])
+            ->withCount('versions')
+            ->orderBy('name')
+            ->paginate($this->perPage($request))
+            ->through(fn ($package) => PackageData::fromModel($package));
+
+        return PackageData::collect($packages, PaginatedDataCollection::class);
+    }
+
+    public function show(Organization $organization, Package $package): PackageData
+    {
+        $this->authorize('view', $organization);
+        $this->ensureBelongsToOrganization($organization, $package);
+
+        $package->load(['repository', 'mirror'])->loadCount('versions');
+
+        return PackageData::fromModel($package);
+    }
+
+    public function destroy(Request $request, Organization $organization, Package $package, RecordActivityTask $recordActivity): Response
+    {
+        $this->authorize('deleteRepository', $organization);
+        $this->ensureBelongsToOrganization($organization, $package);
+
+        $recordActivity->handle(
+            organization: $organization,
+            type: ActivityType::PackageRemoved,
+            subject: $package,
+            actor: $request->user(),
+            properties: ['name' => $package->name],
+        );
+
+        // Delete versions through Eloquent so dist files are cleaned up.
+        $package->versions()->each(fn ($version) => $version->delete());
+
+        $package->delete();
+
+        return response()->noContent();
+    }
+
+    private function ensureBelongsToOrganization(Organization $organization, Package $package): void
+    {
+        abort_unless($package->organization_uuid === $organization->uuid, 404);
+    }
+}

--- a/app/Http/Controllers/Api/V1/PackageVersionController.php
+++ b/app/Http/Controllers/Api/V1/PackageVersionController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Domains\Package\Contracts\Data\PackageVersionData;
+use App\Models\Organization;
+use App\Models\Package;
+use App\Models\PackageVersion;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Spatie\LaravelData\PaginatedDataCollection;
+
+class PackageVersionController extends ApiController
+{
+    /**
+     * @return PaginatedDataCollection<array-key, PackageVersionData>
+     */
+    public function index(Request $request, Organization $organization, Package $package): PaginatedDataCollection
+    {
+        $this->authorize('view', $organization);
+        $this->ensurePackageBelongsToOrganization($organization, $package);
+
+        $provider = $package->repository?->provider;
+        $repoIdentifier = $package->repository?->repo_identifier;
+
+        $versions = $package->versions()
+            ->orderBySemanticVersion('desc')
+            ->paginate($this->perPage($request))
+            ->through(fn ($version) => PackageVersionData::fromModel($version, $provider, $repoIdentifier));
+
+        return PackageVersionData::collect($versions, PaginatedDataCollection::class);
+    }
+
+    public function destroy(Organization $organization, Package $package, PackageVersion $version): Response
+    {
+        $this->authorize('deleteRepository', $organization);
+        $this->ensurePackageBelongsToOrganization($organization, $package);
+
+        abort_unless($version->package_uuid === $package->uuid, 404);
+
+        // Triggers dist file cleanup via the model's deleting event.
+        $version->delete();
+
+        return response()->noContent();
+    }
+
+    private function ensurePackageBelongsToOrganization(Organization $organization, Package $package): void
+    {
+        abort_unless($package->organization_uuid === $organization->uuid, 404);
+    }
+}

--- a/app/Http/Controllers/Api/V1/RepositoryController.php
+++ b/app/Http/Controllers/Api/V1/RepositoryController.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Domains\Activity\Actions\RecordActivityTask;
+use App\Domains\Activity\Contracts\Enums\ActivityType;
+use App\Domains\Repository\Actions\BulkCreateRepositoriesAction;
+use App\Domains\Repository\Actions\CreateRepositoryAction;
+use App\Domains\Repository\Actions\DeleteWebhookAction;
+use App\Domains\Repository\Contracts\Data\BulkImportResultData;
+use App\Domains\Repository\Contracts\Data\RepositoryData;
+use App\Domains\Repository\Contracts\Enums\GitProvider;
+use App\Domains\Repository\Contracts\Enums\RepositorySyncStatus;
+use App\Domains\Repository\Http\Requests\BulkStoreRepositoryRequest;
+use App\Domains\Repository\Http\Requests\StoreRepositoryRequest;
+use App\Domains\Repository\Jobs\SyncRepositoryJob;
+use App\Models\Organization;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Spatie\LaravelData\PaginatedDataCollection;
+
+class RepositoryController extends ApiController
+{
+    public function __construct(
+        protected DeleteWebhookAction $deleteWebhook,
+        protected RecordActivityTask $recordActivity,
+    ) {}
+
+    /**
+     * @return PaginatedDataCollection<array-key, RepositoryData>
+     */
+    public function index(Request $request, Organization $organization): PaginatedDataCollection
+    {
+        $this->authorize('view', $organization);
+
+        $repositories = $organization->repositories()
+            ->withCount('packages')
+            ->orderBy('name')
+            ->paginate($this->perPage($request))
+            ->through(fn ($repository) => RepositoryData::fromModel($repository));
+
+        return RepositoryData::collect($repositories, PaginatedDataCollection::class);
+    }
+
+    public function store(StoreRepositoryRequest $request, Organization $organization, CreateRepositoryAction $createRepository): RepositoryData
+    {
+        $this->authorize('deleteRepository', $organization);
+
+        /** @var User $user */
+        $user = $request->user();
+
+        $repository = $createRepository->handle(
+            organization: $organization,
+            provider: GitProvider::from($request->validated('provider')),
+            repoIdentifier: $request->validated('repo_identifier'),
+            user: $user,
+            name: $request->validated('name'),
+            defaultBranch: $request->validated('default_branch'),
+            sshKeyUuid: $request->validated('ssh_key_uuid'),
+        );
+
+        return RepositoryData::fromModel($repository->loadCount('packages'));
+    }
+
+    public function bulkStore(BulkStoreRepositoryRequest $request, Organization $organization, BulkCreateRepositoriesAction $bulkCreate): BulkImportResultData
+    {
+        $this->authorize('deleteRepository', $organization);
+
+        /** @var User $user */
+        $user = $request->user();
+
+        return $bulkCreate->handle(
+            organization: $organization,
+            provider: GitProvider::from($request->validated('provider')),
+            repositories: $request->validated('repositories'),
+            userUuid: $user->uuid,
+        );
+    }
+
+    public function show(Organization $organization, Repository $repository): RepositoryData
+    {
+        $this->authorize('view', $organization);
+        $this->ensureBelongsToOrganization($organization, $repository);
+
+        return RepositoryData::fromModel($repository->loadCount('packages'));
+    }
+
+    public function sync(Organization $organization, Repository $repository): RepositoryData
+    {
+        $this->authorize('deleteRepository', $organization);
+        $this->ensureBelongsToOrganization($organization, $repository);
+
+        $repository->update(['sync_status' => RepositorySyncStatus::Pending]);
+
+        SyncRepositoryJob::dispatch($repository);
+
+        return RepositoryData::fromModel($repository->loadCount('packages'));
+    }
+
+    public function destroy(Request $request, Organization $organization, Repository $repository): Response
+    {
+        $this->authorize('deleteRepository', $organization);
+        $this->ensureBelongsToOrganization($organization, $repository);
+
+        $this->recordActivity->handle(
+            organization: $organization,
+            type: ActivityType::RepositoryRemoved,
+            subject: $repository,
+            actor: $request->user(),
+            properties: ['name' => $repository->name],
+        );
+
+        $this->deleteWebhook->handle($repository);
+
+        $repository->delete();
+
+        return response()->noContent();
+    }
+
+    private function ensureBelongsToOrganization(Organization $organization, Repository $repository): void
+    {
+        abort_unless($repository->organization_uuid === $organization->uuid, 404);
+    }
+}

--- a/app/Http/Controllers/Api/V1/TokenController.php
+++ b/app/Http/Controllers/Api/V1/TokenController.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Domains\Activity\Actions\RecordActivityTask;
+use App\Domains\Activity\Contracts\Enums\ActivityType;
+use App\Domains\Token\Actions\CreateAccessTokenAction;
+use App\Domains\Token\Actions\UpdateAccessTokenAction;
+use App\Domains\Token\Contracts\Data\AccessTokenData;
+use App\Domains\Token\Contracts\Data\TokenCreatedData;
+use App\Domains\Token\Contracts\Enums\TokenScope;
+use App\Domains\Token\Requests\StoreAccessTokenRequest;
+use App\Domains\Token\Requests\UpdateAccessTokenRequest;
+use App\Domains\Token\Services\TokenScopeChecker;
+use App\Models\AccessToken;
+use App\Models\Organization;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Spatie\LaravelData\PaginatedDataCollection;
+
+class TokenController extends ApiController
+{
+    public function __construct(
+        protected CreateAccessTokenAction $createAccessToken,
+        protected UpdateAccessTokenAction $updateAccessToken,
+        protected TokenScopeChecker $scopeChecker,
+        protected RecordActivityTask $recordActivity,
+    ) {}
+
+    /**
+     * @return PaginatedDataCollection<array-key, AccessTokenData>
+     */
+    public function index(Request $request, Organization $organization): PaginatedDataCollection
+    {
+        $this->authorize('viewSettings', $organization);
+
+        $tokens = $organization->accessTokens()
+            ->orderBy('created_at', 'desc')
+            ->paginate($this->perPage($request))
+            ->through(fn ($token) => AccessTokenData::fromModel($token));
+
+        return AccessTokenData::collect($tokens, PaginatedDataCollection::class);
+    }
+
+    public function store(StoreAccessTokenRequest $request, Organization $organization): TokenCreatedData
+    {
+        $this->authorize('viewSettings', $organization);
+
+        $scopes = $request->validated('scopes') ?? [TokenScope::Composer->value];
+        $this->assertCanGrantScopes($request, $scopes);
+
+        return $this->createAccessToken->handle(
+            organization: $organization,
+            user: null,
+            name: $request->validated('name'),
+            expiresAt: $request->validated('expires_at') ? now()->parse($request->validated('expires_at')) : null,
+            scopes: $scopes,
+        );
+    }
+
+    public function update(UpdateAccessTokenRequest $request, Organization $organization, AccessToken $token): AccessTokenData
+    {
+        $this->authorize('viewSettings', $organization);
+        abort_unless($token->organization_uuid === $organization->uuid, 404);
+
+        $scopes = $request->validated('scopes');
+        if ($scopes !== null) {
+            $this->assertCanGrantScopes($request, $scopes);
+        }
+
+        $this->updateAccessToken->handle(
+            accessToken: $token,
+            name: $request->validated('name'),
+            scopes: $scopes,
+            actor: $request->user(),
+        );
+
+        return AccessTokenData::fromModel($token->refresh());
+    }
+
+    public function destroy(Request $request, Organization $organization, AccessToken $token): Response
+    {
+        $this->authorize('viewSettings', $organization);
+        abort_unless($token->organization_uuid === $organization->uuid, 404);
+
+        $this->recordActivity->handle(
+            organization: $organization,
+            type: ActivityType::TokenRevoked,
+            subject: $token,
+            actor: $request->user(),
+            properties: ['name' => $token->name],
+        );
+
+        $token->delete();
+
+        return response()->noContent();
+    }
+
+    /**
+     * A token may only grant scopes it itself holds (legacy null-scope tokens may grant any).
+     *
+     * @param  array<int, string>  $scopeValues
+     */
+    private function assertCanGrantScopes(Request $request, array $scopeValues): void
+    {
+        $accessToken = $this->accessToken($request);
+
+        foreach ($scopeValues as $value) {
+            if (! $this->scopeChecker->hasScope($accessToken, TokenScope::from($value))) {
+                abort(403, "Token cannot grant the '{$value}' scope it does not itself hold.");
+            }
+        }
+    }
+}

--- a/app/Http/Controllers/Api/V1/UserController.php
+++ b/app/Http/Controllers/Api/V1/UserController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Domains\Organization\Contracts\Data\OrganizationData;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Spatie\LaravelData\PaginatedDataCollection;
+
+class UserController extends ApiController
+{
+    /**
+     * Get the authenticated user's profile.
+     *
+     * @return array{uuid: string, name: string, email: string, avatar: string|null}
+     */
+    public function show(Request $request): array
+    {
+        $this->requirePersonalAccessToken($request);
+
+        /** @var User $user */
+        $user = $request->user();
+
+        return [
+            'uuid' => $user->uuid,
+            'name' => $user->name,
+            'email' => $user->email,
+            'avatar' => $user->avatar,
+        ];
+    }
+
+    /**
+     * List the organizations the authenticated user belongs to.
+     *
+     * @return PaginatedDataCollection<array-key, OrganizationData>
+     */
+    public function organizations(Request $request): PaginatedDataCollection
+    {
+        $this->requirePersonalAccessToken($request);
+
+        /** @var User $user */
+        $user = $request->user();
+
+        $organizations = $user->organizations()
+            ->orderBy('name')
+            ->paginate($this->perPage($request))
+            ->through(fn ($organization) => OrganizationData::fromModel($organization));
+
+        return OrganizationData::collect($organizations, PaginatedDataCollection::class);
+    }
+}

--- a/app/Http/Controllers/Api/V1/UserTokenController.php
+++ b/app/Http/Controllers/Api/V1/UserTokenController.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Domains\Token\Actions\CreateAccessTokenAction;
+use App\Domains\Token\Actions\UpdateAccessTokenAction;
+use App\Domains\Token\Contracts\Data\AccessTokenData;
+use App\Domains\Token\Contracts\Data\TokenCreatedData;
+use App\Domains\Token\Contracts\Enums\TokenScope;
+use App\Domains\Token\Requests\StoreAccessTokenRequest;
+use App\Domains\Token\Requests\UpdateAccessTokenRequest;
+use App\Domains\Token\Services\TokenScopeChecker;
+use App\Models\AccessToken;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Spatie\LaravelData\PaginatedDataCollection;
+
+class UserTokenController extends ApiController
+{
+    public function __construct(
+        protected CreateAccessTokenAction $createAccessToken,
+        protected UpdateAccessTokenAction $updateAccessToken,
+        protected TokenScopeChecker $scopeChecker,
+    ) {}
+
+    /**
+     * @return PaginatedDataCollection<array-key, AccessTokenData>
+     */
+    public function index(Request $request): PaginatedDataCollection
+    {
+        $this->requirePersonalAccessToken($request);
+
+        /** @var User $user */
+        $user = $request->user();
+
+        $tokens = $user->accessTokens()
+            ->orderBy('created_at', 'desc')
+            ->paginate($this->perPage($request))
+            ->through(fn ($token) => AccessTokenData::fromModel($token));
+
+        return AccessTokenData::collect($tokens, PaginatedDataCollection::class);
+    }
+
+    public function store(StoreAccessTokenRequest $request): TokenCreatedData
+    {
+        $this->requirePersonalAccessToken($request);
+
+        /** @var User $user */
+        $user = $request->user();
+
+        $scopes = $request->validated('scopes') ?? [TokenScope::Composer->value];
+        $this->assertCanGrantScopes($request, $scopes);
+
+        return $this->createAccessToken->handle(
+            organization: null,
+            user: $user,
+            name: $request->validated('name'),
+            expiresAt: $request->validated('expires_at') ? now()->parse($request->validated('expires_at')) : null,
+            scopes: $scopes,
+        );
+    }
+
+    public function update(UpdateAccessTokenRequest $request, AccessToken $token): AccessTokenData
+    {
+        $this->requirePersonalAccessToken($request);
+
+        /** @var User $user */
+        $user = $request->user();
+
+        abort_unless($token->user_uuid === $user->uuid, 404);
+
+        $scopes = $request->validated('scopes');
+        if ($scopes !== null) {
+            $this->assertCanGrantScopes($request, $scopes);
+        }
+
+        $this->updateAccessToken->handle(
+            accessToken: $token,
+            name: $request->validated('name'),
+            scopes: $scopes,
+            actor: $user,
+        );
+
+        return AccessTokenData::fromModel($token->refresh());
+    }
+
+    public function destroy(Request $request, AccessToken $token): Response
+    {
+        $this->requirePersonalAccessToken($request);
+
+        /** @var User $user */
+        $user = $request->user();
+
+        abort_unless($token->user_uuid === $user->uuid, 404);
+
+        $token->delete();
+
+        return response()->noContent();
+    }
+
+    /**
+     * A token may only grant scopes it itself holds (legacy null-scope tokens may grant any).
+     *
+     * @param  array<int, string>  $scopeValues
+     */
+    private function assertCanGrantScopes(Request $request, array $scopeValues): void
+    {
+        $accessToken = $this->accessToken($request);
+
+        foreach ($scopeValues as $value) {
+            if (! $this->scopeChecker->hasScope($accessToken, TokenScope::from($value))) {
+                abort(403, "Token cannot grant the '{$value}' scope it does not itself hold.");
+            }
+        }
+    }
+}

--- a/app/Http/Middleware/ApiTokenAuth.php
+++ b/app/Http/Middleware/ApiTokenAuth.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Domains\Token\Services\AccessTokenResolver;
+use App\Models\AccessToken;
+use App\Models\Organization;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class ApiTokenAuth
+{
+    public function __construct(
+        protected AccessTokenResolver $accessTokenResolver,
+    ) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $accessToken = $this->accessTokenResolver->fromRequest($request);
+
+        if (! $accessToken || ! $accessToken->isValid()) {
+            return $this->unauthorized();
+        }
+
+        // Establish the acting user so existing policies and Form Requests work:
+        // a personal access token acts as its user; an organization token acts as
+        // the organization's owner (always a member with the owner role).
+        if ($accessToken->user_uuid && $accessToken->user) {
+            Auth::setUser($accessToken->user);
+        } elseif ($accessToken->organization_uuid && $accessToken->organization?->owner) {
+            Auth::setUser($accessToken->organization->owner);
+            $request->attributes->set('api_token_organization', $accessToken->organization);
+        } else {
+            // Token references a missing user/organization (e.g. soft-deleted org).
+            return $this->unauthorized();
+        }
+
+        // An organization-scoped token may only ever act on its own organization,
+        // regardless of who its owner is a member of elsewhere.
+        if ($accessToken->organization_uuid && ! $this->organizationMatches($request, $accessToken)) {
+            return $this->forbidden();
+        }
+
+        $accessToken->markAsUsed();
+
+        $request->merge(['accessToken' => $accessToken]);
+
+        return $next($request);
+    }
+
+    protected function organizationMatches(Request $request, AccessToken $accessToken): bool
+    {
+        $routeOrganization = $request->route('organization');
+
+        // No organization in the route (e.g. /user, /organizations) — nothing to mismatch.
+        if ($routeOrganization === null) {
+            return true;
+        }
+
+        if ($routeOrganization instanceof Organization) {
+            return $routeOrganization->uuid === $accessToken->organization_uuid;
+        }
+
+        $organization = Organization::where('slug', $routeOrganization)->first();
+
+        return $organization !== null && $organization->uuid === $accessToken->organization_uuid;
+    }
+
+    protected function unauthorized(): Response
+    {
+        return response()->json([
+            'message' => 'Unauthenticated.',
+        ], 401, [
+            'WWW-Authenticate' => 'Bearer realm="Pricore"',
+        ]);
+    }
+
+    protected function forbidden(): Response
+    {
+        return response()->json([
+            'message' => 'This token cannot access this organization.',
+        ], 403);
+    }
+}

--- a/app/Http/Middleware/ComposerTokenAuth.php
+++ b/app/Http/Middleware/ComposerTokenAuth.php
@@ -2,6 +2,9 @@
 
 namespace App\Http\Middleware;
 
+use App\Domains\Token\Contracts\Enums\TokenScope;
+use App\Domains\Token\Services\AccessTokenResolver;
+use App\Domains\Token\Services\TokenScopeChecker;
 use App\Models\AccessToken;
 use App\Models\Organization;
 use Closure;
@@ -10,18 +13,21 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ComposerTokenAuth
 {
+    public function __construct(
+        protected AccessTokenResolver $accessTokenResolver,
+        protected TokenScopeChecker $scopeChecker,
+    ) {}
+
     public function handle(Request $request, Closure $next): Response
     {
-        $token = $this->extractToken($request);
-
-        if (! $token) {
-            return $this->unauthorized();
-        }
-
-        $accessToken = $this->findAccessToken($token);
+        $accessToken = $this->accessTokenResolver->fromRequest($request);
 
         if (! $accessToken || ! $accessToken->isValid()) {
             return $this->unauthorized();
+        }
+
+        if (! $this->scopeChecker->hasScope($accessToken, TokenScope::Composer)) {
+            return $this->forbidden();
         }
 
         $organization = $request->route('organization');
@@ -40,46 +46,6 @@ class ComposerTokenAuth
         $request->merge(['accessToken' => $accessToken]);
 
         return $next($request);
-    }
-
-    protected function extractToken(Request $request): ?string
-    {
-        $header = $request->header('Authorization');
-
-        if (! $header) {
-            return null;
-        }
-
-        // Check for Bearer token
-        if (preg_match('/^Bearer\s+(.+)$/i', $header, $matches)) {
-            return $matches[1];
-        }
-
-        // Check for Basic auth (token as password, username is ignored)
-        if (preg_match('/^Basic\s+(.+)$/i', $header, $matches)) {
-            $decoded = base64_decode($matches[1], true);
-            if ($decoded === false) {
-                return null;
-            }
-
-            // Basic auth format: username:password
-            // The token must be in the password field (e.g., "token:YOUR_TOKEN")
-            $parts = explode(':', $decoded, 2);
-
-            return $parts[1] ?? null;
-        }
-
-        return null;
-    }
-
-    protected function findAccessToken(string $token): ?AccessToken
-    {
-        $tokenHash = hash('sha256', $token);
-
-        return AccessToken::query()
-            ->where('token_hash', $tokenHash)
-            ->with(['organization', 'user'])
-            ->first();
     }
 
     protected function canAccessOrganization(AccessToken $accessToken, ?Organization $organization): bool
@@ -110,5 +76,12 @@ class ComposerTokenAuth
         ], 401, [
             'WWW-Authenticate' => 'Bearer realm="Pricore"',
         ]);
+    }
+
+    protected function forbidden(): Response
+    {
+        return response()->json([
+            'message' => 'This token does not have Composer registry access.',
+        ], 403);
     }
 }

--- a/app/Http/Middleware/RequireTokenScope.php
+++ b/app/Http/Middleware/RequireTokenScope.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Domains\Token\Contracts\Enums\TokenScope;
+use App\Domains\Token\Services\TokenScopeChecker;
+use App\Models\AccessToken;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequireTokenScope
+{
+    public function __construct(
+        protected TokenScopeChecker $scopeChecker,
+    ) {}
+
+    /**
+     * Usage: ->middleware('scope:write:repositories'). Multiple comma-separated
+     * scopes are treated as "any of"; chain two scope middlewares for "all of".
+     */
+    public function handle(Request $request, Closure $next, string ...$scopes): Response
+    {
+        $accessToken = $request->get('accessToken');
+
+        if (! $accessToken instanceof AccessToken) {
+            return $this->unauthorized();
+        }
+
+        $required = array_map(
+            fn (string $scope) => TokenScope::from($scope),
+            $scopes,
+        );
+
+        if (! $this->scopeChecker->hasAny($accessToken, ...$required)) {
+            return response()->json([
+                'message' => 'Insufficient token scope.',
+                'required_scope' => $scopes[0] ?? null,
+            ], 403);
+        }
+
+        return $next($request);
+    }
+
+    protected function unauthorized(): Response
+    {
+        return response()->json([
+            'message' => 'Unauthenticated.',
+        ], 401, [
+            'WWW-Authenticate' => 'Bearer realm="Pricore"',
+        ]);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,8 +12,12 @@ use App\Models\Repository;
 use App\Models\User;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Registered;
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 use SocialiteProviders\GitLab\GitLabExtendSocialite;
@@ -43,5 +47,16 @@ class AppServiceProvider extends ServiceProvider
             'organization_ssh_key' => OrganizationSshKey::class,
             'mirror' => Mirror::class,
         ]);
+
+        RateLimiter::for('api', function (Request $request) {
+            $accessToken = $request->get('accessToken');
+            $key = $accessToken instanceof AccessToken ? $accessToken->uuid : (string) $request->ip();
+
+            return Limit::perMinute(120)->by($key);
+        });
+
+        // Scramble auto-allows API docs in the local environment; elsewhere
+        // restrict the interactive docs UI to authenticated users.
+        Gate::define('viewApiDocs', fn (?User $user) => $user !== null);
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,9 +1,11 @@
 <?php
 
+use App\Http\Middleware\ApiTokenAuth;
 use App\Http\Middleware\ComposerTokenAuth;
 use App\Http\Middleware\EnsureOrganizationMembership;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
+use App\Http\Middleware\RequireTokenScope;
 use App\Http\Middleware\TrackOrganizationAccess;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -21,6 +23,11 @@ return Application::configure(basePath: dirname(__DIR__))
         channels: __DIR__.'/../routes/channels.php',
         health: '/up',
         then: function () {
+            Route::middleware('api')
+                ->prefix('api/v1')
+                ->name('api.v1.')
+                ->group(base_path('routes/api.php'));
+
             Route::middleware('api')
                 ->group(base_path('routes/composer.php'));
 
@@ -47,6 +54,8 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $middleware->alias([
             'composer.token' => ComposerTokenAuth::class,
+            'api.token' => ApiTokenAuth::class,
+            'scope' => RequireTokenScope::class,
             'organization.member' => EnsureOrganizationMembership::class,
             'track.organization' => TrackOrganizationAccess::class,
         ]);

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "aws/aws-sdk-php": "^3.369",
         "composer/metadata-minifier": "^1.0",
         "composer/semver": "^3.4",
+        "dedoc/scramble": "^0.13.27",
         "inertiajs/inertia-laravel": "^3.0",
         "laravel/fortify": "^1.30",
         "laravel/framework": "^13.0",
@@ -101,6 +102,9 @@
         ],
         "ts": [
             "@php artisan typescript:transform"
+        ],
+        "api:docs": [
+            "@php artisan scramble:export --path=docs/public/openapi.json"
         ],
         "cloud:link": [
             "composer config repositories.pricore-cloud path ../pricore-cloud",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6e6d4b3a092b3e6e320bd210acfe9a45",
+    "content-hash": "c54a28c4d51ffe5ad2ef9eb2fcc72f63",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -666,6 +666,86 @@
                 "source": "https://github.com/DASPRiD/Enum/tree/1.0.7"
             },
             "time": "2025-09-16T12:23:56+00:00"
+        },
+        {
+            "name": "dedoc/scramble",
+            "version": "v0.13.27",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dedoc/scramble.git",
+                "reference": "5b067b1168b4092ee10b320469a09823610f48b1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dedoc/scramble/zipball/5b067b1168b4092ee10b320469a09823610f48b1",
+                "reference": "5b067b1168b4092ee10b320469a09823610f48b1",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+                "myclabs/deep-copy": "^1.12",
+                "nikic/php-parser": "^5.0",
+                "php": "^8.1",
+                "phpstan/phpdoc-parser": "^1.0|^2.0",
+                "spatie/laravel-package-tools": "^1.9.2"
+            },
+            "require-dev": {
+                "larastan/larastan": "^3.3",
+                "laravel/pint": "^v1.1.0",
+                "nunomaduro/collision": "^7.0|^8.0",
+                "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+                "pestphp/pest": "^2.34|^3.7|^4.4",
+                "pestphp/pest-plugin-laravel": "^2.3|^3.1|^4.1",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5|^11.5.3|^12.5.12",
+                "spatie/laravel-permission": "^6.10|^7.2",
+                "spatie/pest-plugin-snapshots": "^2.1"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Dedoc\\Scramble\\ScrambleServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dedoc\\Scramble\\": "src",
+                    "Dedoc\\Scramble\\Database\\Factories\\": "database/factories"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Lytvynenko",
+                    "email": "litvinenko95@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Automatic generation of API documentation for Laravel applications.",
+            "homepage": "https://github.com/dedoc/scramble",
+            "keywords": [
+                "documentation",
+                "laravel",
+                "openapi"
+            ],
+            "support": {
+                "issues": "https://github.com/dedoc/scramble/issues",
+                "source": "https://github.com/dedoc/scramble/tree/v0.13.27"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/romalytvynenko",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-12T12:41:44+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -3635,6 +3715,66 @@
                 "source": "https://github.com/jmespath/jmespath.php/tree/2.8.0"
             },
             "time": "2024-09-04T18:46:31+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -11732,66 +11872,6 @@
                 "source": "https://github.com/mockery/mockery"
             },
             "time": "2024-05-16T03:13:13+00:00"
-        },
-        {
-            "name": "myclabs/deep-copy",
-            "version": "1.13.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "conflict": {
-                "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
-            },
-            "require-dev": {
-                "doctrine/collections": "^1.6.8",
-                "doctrine/common": "^2.13.3 || ^3.2.2",
-                "phpspec/prophecy": "^1.10",
-                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/DeepCopy/deep_copy.php"
-                ],
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Create deep copies (clones) of your objects",
-            "keywords": [
-                "clone",
-                "copy",
-                "duplicate",
-                "object",
-                "object graph"
-            ],
-            "support": {
-                "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
-            },
-            "funding": [
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-01T08:46:24+00:00"
         },
         {
             "name": "nunomaduro/collision",

--- a/config/scramble.php
+++ b/config/scramble.php
@@ -1,0 +1,181 @@
+<?php
+
+use Dedoc\Scramble\Http\Middleware\RestrictedDocsAccess;
+use Dedoc\Scramble\SecurityDocumentation\MiddlewareAuthSecurityStrategy;
+use Dedoc\Scramble\Support\Generator\SecurityScheme;
+
+return [
+    /*
+     * Which routes to document. String or array form; use Scramble::routes() for custom selection.
+     *
+     * 'api_path' => [
+     *     'include' => 'api',
+     *     'exclude' => ['api/internal'],
+     * ],
+     *
+     * Without *, patterns match path segments (api matches api and api/users, not apiary).
+     * With *, Str::is is used (e.g. api/v*).
+     *
+     * One static include → default server is /{include} and paths are stripped (/users).
+     * Multiple includes or wildcards → server defaults to / and paths stay full (/api/users).
+     * Override with `servers`, or use Scramble::registerApi() for separate bases.
+     */
+    'api_path' => 'api/v1',
+
+    /*
+     * Your API domain. By default, app domain is used. This is also a part of the default API routes
+     * matcher, so when implementing your own, make sure you use this config if needed.
+     */
+    'api_domain' => null,
+
+    /*
+     * The path where your OpenAPI specification will be exported.
+     */
+    'export_path' => 'docs/public/openapi.json',
+
+    /*
+     * Cache configuration for the generated OpenAPI document.
+     *
+     * Use `scramble:cache` to warm the cache and `scramble:clear` to invalidate it.
+     */
+    'cache' => [
+        'key' => 'scramble.openapi',
+        'store' => 'file',
+    ],
+
+    'info' => [
+        /*
+         * API version.
+         */
+        'version' => env('API_VERSION', 'v1'),
+
+        /*
+         * Description rendered on the home page of the API documentation (`/docs/api`).
+         */
+        'description' => 'REST API for managing a Pricore registry: organizations, repositories, packages, members, mirrors, and access tokens. Authenticate with a personal or organization access token sent as `Authorization: Bearer <token>`.',
+    ],
+
+    'ui' => [
+        'title' => 'Pricore API',
+    ],
+
+    'renderer' => 'elements',
+
+    'renderers' => [
+        /*
+         * Stoplight Elements config options: https://docs.stoplight.io/docs/elements/b074dc47b2826-elements-configuration-options
+         */
+        'elements' => [
+            'view' => 'scramble::docs',
+            'theme' => 'light',
+            'hideTryIt' => false,
+            'hideSchemas' => false,
+            'logo' => '',
+            'tryItCredentialsPolicy' => 'include',
+            'layout' => 'responsive',
+            'router' => 'hash',
+        ],
+        /*
+         * Scalar API reference config options: https://scalar.com/products/api-references/configuration
+         */
+        'scalar' => [
+            'view' => 'scramble::scalar',
+            'cdn' => 'https://cdn.jsdelivr.net/npm/@scalar/api-reference',
+            'theme' => 'laravel',
+            'proxyUrl' => 'https://proxy.scalar.com',
+            'darkMode' => false,
+            'showDeveloperTools' => 'never',
+            'agent' => ['disabled' => true],
+            'credentials' => 'include',
+        ],
+    ],
+
+    /*
+     * The list of servers of the API. By default, when `null`, server URL will be created from
+     * `scramble.api_path` and `scramble.api_domain` config variables. When providing an array, you
+     * will need to specify the local server URL manually (if needed).
+     *
+     * Example of non-default config (final URLs are generated using Laravel `url` helper):
+     *
+     * ```php
+     * 'servers' => [
+     *     'Live' => 'api',
+     *     'Prod' => 'https://scramble.dedoc.co/api',
+     * ],
+     * ```
+     */
+    'servers' => null,
+
+    /**
+     * Determines how Scramble stores the descriptions of enum cases.
+     * Available options:
+     * - 'description' – Case descriptions are stored as the enum schema's description using table formatting.
+     * - 'extension' – Case descriptions are stored in the `x-enumDescriptions` enum schema extension.
+     *
+     *    @see https://redocly.com/docs-legacy/api-reference-docs/specification-extensions/x-enum-descriptions
+     * - false - Case descriptions are ignored.
+     */
+    'enum_cases_description_strategy' => 'description',
+
+    /**
+     * Determines how Scramble stores the names of enum cases.
+     * Available options:
+     * - 'names' – Case names are stored in the `x-enumNames` enum schema extension.
+     * - 'varnames' - Case names are stored in the `x-enum-varnames` enum schema extension.
+     * - false - Case names are not stored.
+     */
+    'enum_cases_names_strategy' => false,
+
+    /**
+     * When Scramble encounters deep objects in query parameters, it flattens the parameters so the generated
+     * OpenAPI document correctly describes the API. Flattening deep query parameters is relevant until
+     * OpenAPI 3.2 is released and query string structure can be described properly.
+     *
+     * For example, this nested validation rule describes the object with `bar` property:
+     * `['foo.bar' => ['required', 'int']]`.
+     *
+     * When `flatten_deep_query_parameters` is `true`, Scramble will document the parameter like so:
+     * `{"name":"foo[bar]", "schema":{"type":"int"}, "required":true}`.
+     *
+     * When `flatten_deep_query_parameters` is `false`, Scramble will document the parameter like so:
+     *  `{"name":"foo", "schema": {"type":"object", "properties":{"bar":{"type": "int"}}, "required": ["bar"]}, "required":true}`.
+     */
+    'flatten_deep_query_parameters' => true,
+
+    'middleware' => [
+        'web',
+        RestrictedDocsAccess::class,
+    ],
+
+    'extensions' => [],
+
+    /*
+     * Automatically document API security (OpenAPI `security` / `securitySchemes`) based on route
+     * middleware.
+     *
+     * Disabled by default. Uncomment the line below to enable `MiddlewareAuthSecurityStrategy`.
+     * When at least one documented route uses middleware matching the configured patterns (by default
+     * `auth` and `auth:*`), bearer auth is applied globally. Routes without matching middleware are
+     * marked as public (`security: []`).
+     *
+     * Set to `null` explicitly to disable. If you already configure security manually via
+     * `afterOpenApiGenerated` / `extendOpenApi`, keep this disabled to avoid duplicate schemes.
+     *
+     * Customize with a class-string or [class, options]:
+     *
+     * 'security_strategy' => [
+     *     \Dedoc\Scramble\SecurityDocumentation\MiddlewareAuthSecurityStrategy::class,
+     *     [
+     *         'middleware' => ['auth', 'auth:*'],
+     *         'scheme' => \Dedoc\Scramble\Support\Generator\SecurityScheme::http('bearer'),
+     *     ],
+     * ],
+     */
+    'security_strategy' => [
+        MiddlewareAuthSecurityStrategy::class,
+        [
+            'middleware' => ['api.token'],
+            'scheme' => SecurityScheme::http('bearer'),
+        ],
+    ],
+];

--- a/database/factories/AccessTokenFactory.php
+++ b/database/factories/AccessTokenFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Domains\Token\Contracts\Enums\TokenScope;
 use App\Models\AccessToken;
 use App\Models\Organization;
 use App\Models\User;
@@ -33,7 +34,7 @@ class AccessTokenFactory extends Factory
             'user_uuid' => null,
             'name' => fake()->words(2, true).' Token',
             'token_hash' => hash('sha256', Str::random(64)),
-            'scopes' => fake()->optional(0.6)->randomElements(['read', 'write', 'admin'], fake()->numberBetween(1, 3)),
+            'scopes' => null,
             'last_used_at' => fake()->optional(0.7)->dateTimeBetween('-30 days', 'now'),
             'expires_at' => fake()->optional(0.5)->dateTimeBetween('now', '+2 years'),
         ];
@@ -84,13 +85,24 @@ class AccessTokenFactory extends Factory
     /**
      * Indicate that the token has specific scopes.
      *
-     * @param  array<string>  $scopes
+     * @param  array<int, TokenScope|string>  $scopes
      */
     public function withScopes(array $scopes): static
     {
         return $this->state(fn (array $attributes) => [
-            'scopes' => $scopes,
+            'scopes' => array_map(
+                fn (TokenScope|string $scope) => $scope instanceof TokenScope ? $scope->value : $scope,
+                $scopes,
+            ),
         ]);
+    }
+
+    /**
+     * Indicate that the token is limited to Composer registry access.
+     */
+    public function composerOnly(): static
+    {
+        return $this->withScopes([TokenScope::Composer]);
     }
 
     /**

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,10 +1,79 @@
 # API Reference
 
-Pricore provides a Composer-compatible API for package distribution and webhook endpoints for automatic syncing.
+Pricore exposes three HTTP interfaces:
 
-## Authentication
+- **Management API (REST)** — a JSON API under `/api/v1` for managing organizations, repositories, packages, members, mirrors, and access tokens programmatically.
+- **Composer Repository API** — the Composer v2-compatible endpoints used by `composer` to resolve and download packages.
+- **Webhooks** — endpoints your Git provider calls to trigger automatic syncing.
 
-The Composer API requires authentication via access token. Two methods are supported:
+## Management API (REST)
+
+The Management API lets you automate Pricore — for example, an installer can mint a Composer token and connect a repository without anyone touching the UI.
+
+- **Base URL:** `https://pricore.yourcompany.com/api/v1`
+- **Format:** JSON. Send `Accept: application/json`.
+- **Interactive docs:** browse and try endpoints at `/docs/api`. The full OpenAPI 3.1 specification is published at [`/openapi.json`](/openapi.json).
+- **Rate limit:** 120 requests/minute per token.
+
+### Authentication
+
+Send an access token as a Bearer token:
+
+```bash
+curl -H "Authorization: Bearer YOUR_TOKEN" \
+     -H "Accept: application/json" \
+     https://pricore.yourcompany.com/api/v1/user
+```
+
+Two kinds of token work:
+
+- **Personal access tokens** act as your user and can reach every organization you belong to. Create them under **Settings → Access Tokens**, or via `POST /api/v1/user/tokens`.
+- **Organization tokens** are scoped to a single organization. Create them under the organization's token settings, or via `POST /api/v1/organizations/{organization}/tokens`.
+
+### Scopes
+
+Every token carries a set of scopes that limit what it can do. Requests are checked against both the token's scopes **and** your role in the organization, so a token can never exceed its owner's permissions. Tokens created before scopes existed retain full access.
+
+| Scope | Grants |
+|-------|--------|
+| `composer` | Composer registry access (package resolution & downloads) |
+| `read:organizations` / `write:organizations` / `delete:organizations` | View / create & update / delete organizations |
+| `read:repositories` / `write:repositories` / `delete:repositories` | View / add & sync / delete repositories |
+| `read:packages` / `write:packages` / `delete:packages` | View / manage / delete packages & versions |
+| `read:members` / `write:members` | View / manage members & invitations |
+| `read:mirrors` / `write:mirrors` / `delete:mirrors` | View / add & sync / delete mirrors |
+| `read:tokens` / `write:tokens` | View / create & revoke access tokens |
+
+### Pagination
+
+List endpoints return a paginated envelope. Use `?page=` and `?per_page=` (max 100) to navigate:
+
+```json
+{
+    "data": [ /* … */ ],
+    "links": { "first": "…", "last": "…", "prev": null, "next": "…" },
+    "meta": { "current_page": 1, "per_page": 25, "total": 42 }
+}
+```
+
+### Resources
+
+| Resource | Endpoints |
+|----------|-----------|
+| User | `GET /user`, `GET /user/organizations`, `GET\|POST\|DELETE /user/tokens` |
+| Organizations | `GET\|POST /organizations`, `GET\|PATCH\|DELETE /organizations/{organization}` |
+| Repositories | `GET\|POST /…/repositories`, `POST /…/repositories/bulk`, `GET\|POST(sync)\|DELETE /…/repositories/{uuid}` |
+| Packages | `GET /…/packages`, `GET\|DELETE /…/packages/{uuid}`, `GET /…/packages/{uuid}/versions`, `DELETE /…/packages/{uuid}/versions/{uuid}` |
+| Members | `GET\|POST /…/members`, `PATCH\|DELETE /…/members/{uuid}` |
+| Invitations | `GET /…/invitations`, `POST /…/invitations/{uuid}/resend`, `DELETE /…/invitations/{uuid}` |
+| Mirrors | `GET\|POST /…/mirrors`, `GET\|POST(sync)\|DELETE /…/mirrors/{uuid}` |
+| Tokens | `GET\|POST /…/tokens`, `DELETE /…/tokens/{uuid}` |
+
+See the [OpenAPI specification](/openapi.json) for request/response schemas of every endpoint.
+
+## Composer API Authentication
+
+The Composer API requires authentication via an access token that carries the `composer` scope (tokens created before scopes existed retain access). Two methods are supported:
 
 ### HTTP Basic Auth
 

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1,0 +1,1990 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Pricore API",
+        "version": "v1",
+        "description": "REST API for managing a Pricore registry: organizations, repositories, packages, members, mirrors, and access tokens. Authenticate with a personal or organization access token sent as `Authorization: Bearer <token>`."
+    },
+    "servers": [
+        {
+            "url": "http://pricore.test/api/v1"
+        }
+    ],
+    "security": [
+        {
+            "http": []
+        }
+    ],
+    "paths": {
+        "/organizations/{organization}/invitations": {
+            "get": {
+                "operationId": "v1.invitations.index",
+                "tags": [
+                    "Invitation"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "`PaginatedDataCollection`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedDataCollection"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            }
+        },
+        "/organizations/{organization}/invitations/{invitation}/resend": {
+            "post": {
+                "operationId": "v1.invitations.resend",
+                "tags": [
+                    "Invitation"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "invitation",
+                        "in": "path",
+                        "required": true,
+                        "description": "The invitation UUID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "`OrganizationInvitationData`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OrganizationInvitationData"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "An error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "description": "Error overview.",
+                                            "example": "This invitation has already been accepted."
+                                        }
+                                    },
+                                    "required": [
+                                        "message"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            }
+        },
+        "/organizations/{organization}/invitations/{invitation}": {
+            "delete": {
+                "operationId": "v1.invitations.destroy",
+                "tags": [
+                    "Invitation"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "invitation",
+                        "in": "path",
+                        "required": true,
+                        "description": "The invitation UUID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            }
+        },
+        "/organizations/{organization}/members": {
+            "get": {
+                "operationId": "v1.members.index",
+                "tags": [
+                    "Member"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "`PaginatedDataCollection`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedDataCollection"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            },
+            "post": {
+                "operationId": "v1.members.store",
+                "tags": [
+                    "Member"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AddMemberRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "`OrganizationInvitationData`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OrganizationInvitationData"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationException"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            }
+        },
+        "/organizations/{organization}/members/{member}": {
+            "patch": {
+                "operationId": "v1.members.update",
+                "tags": [
+                    "Member"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "member",
+                        "in": "path",
+                        "required": true,
+                        "description": "The member UUID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateMemberRoleRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "`OrganizationMemberData`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OrganizationMemberData"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationException"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "v1.members.destroy",
+                "tags": [
+                    "Member"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "member",
+                        "in": "path",
+                        "required": true,
+                        "description": "The member UUID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    },
+                    "422": {
+                        "description": "An error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "description": "Error overview.",
+                                            "example": "Cannot remove the organization owner."
+                                        }
+                                    },
+                                    "required": [
+                                        "message"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            }
+        },
+        "/organizations/{organization}/mirrors": {
+            "get": {
+                "operationId": "v1.mirrors.index",
+                "tags": [
+                    "Mirror"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "`PaginatedDataCollection`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedDataCollection"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            },
+            "post": {
+                "operationId": "v1.mirrors.store",
+                "tags": [
+                    "Mirror"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/StoreMirrorRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "`MirrorData`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MirrorData"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationException"
+                    }
+                }
+            }
+        },
+        "/organizations/{organization}/mirrors/{mirror}": {
+            "get": {
+                "operationId": "v1.mirrors.show",
+                "tags": [
+                    "Mirror"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "mirror",
+                        "in": "path",
+                        "required": true,
+                        "description": "The mirror UUID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "`MirrorData`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MirrorData"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "v1.mirrors.destroy",
+                "tags": [
+                    "Mirror"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "mirror",
+                        "in": "path",
+                        "required": true,
+                        "description": "The mirror UUID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            }
+        },
+        "/organizations/{organization}/mirrors/{mirror}/sync": {
+            "post": {
+                "operationId": "v1.mirrors.sync",
+                "tags": [
+                    "Mirror"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "mirror",
+                        "in": "path",
+                        "required": true,
+                        "description": "The mirror UUID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "`MirrorData`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MirrorData"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            }
+        },
+        "/organizations": {
+            "get": {
+                "operationId": "v1.organizations.index",
+                "summary": "List organizations accessible to the authenticated token",
+                "tags": [
+                    "Organization"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "`PaginatedDataCollection`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedDataCollection"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "operationId": "v1.organizations.store",
+                "summary": "Create a new organization owned by the authenticated user",
+                "tags": [
+                    "Organization"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/StoreOrganizationRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "`OrganizationData`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OrganizationData"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationException"
+                    }
+                }
+            }
+        },
+        "/organizations/{organization}": {
+            "get": {
+                "operationId": "v1.organizations.show",
+                "tags": [
+                    "Organization"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "`OrganizationData`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OrganizationData"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "v1.organizations.update",
+                "tags": [
+                    "Organization"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateOrganizationRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "`OrganizationData`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OrganizationData"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationException"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "v1.organizations.destroy",
+                "tags": [
+                    "Organization"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            }
+        },
+        "/organizations/{organization}/packages": {
+            "get": {
+                "operationId": "v1.packages.index",
+                "tags": [
+                    "Package"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "`PaginatedDataCollection`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedDataCollection"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            }
+        },
+        "/organizations/{organization}/packages/{package}": {
+            "get": {
+                "operationId": "v1.packages.show",
+                "tags": [
+                    "Package"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "package",
+                        "in": "path",
+                        "required": true,
+                        "description": "The package UUID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "`PackageData`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PackageData"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "v1.packages.destroy",
+                "tags": [
+                    "Package"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "package",
+                        "in": "path",
+                        "required": true,
+                        "description": "The package UUID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            }
+        },
+        "/organizations/{organization}/packages/{package}/versions": {
+            "get": {
+                "operationId": "v1.packages.versions.index",
+                "tags": [
+                    "PackageVersion"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "package",
+                        "in": "path",
+                        "required": true,
+                        "description": "The package UUID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "`PaginatedDataCollection`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedDataCollection"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            }
+        },
+        "/organizations/{organization}/packages/{package}/versions/{version}": {
+            "delete": {
+                "operationId": "v1.packages.versions.destroy",
+                "tags": [
+                    "PackageVersion"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "package",
+                        "in": "path",
+                        "required": true,
+                        "description": "The package UUID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "version",
+                        "in": "path",
+                        "required": true,
+                        "description": "The version UUID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            }
+        },
+        "/organizations/{organization}/repositories": {
+            "get": {
+                "operationId": "v1.repositories.index",
+                "tags": [
+                    "Repository"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "`PaginatedDataCollection`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedDataCollection"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            },
+            "post": {
+                "operationId": "v1.repositories.store",
+                "tags": [
+                    "Repository"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/StoreRepositoryRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "`RepositoryData`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RepositoryData"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationException"
+                    }
+                }
+            }
+        },
+        "/organizations/{organization}/repositories/bulk": {
+            "post": {
+                "operationId": "v1.repositories.bulk",
+                "tags": [
+                    "Repository"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BulkStoreRepositoryRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "`BulkImportResultData`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BulkImportResultData"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationException"
+                    }
+                }
+            }
+        },
+        "/organizations/{organization}/repositories/{repository}": {
+            "get": {
+                "operationId": "v1.repositories.show",
+                "tags": [
+                    "Repository"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "repository",
+                        "in": "path",
+                        "required": true,
+                        "description": "The repository UUID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "`RepositoryData`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RepositoryData"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "v1.repositories.destroy",
+                "tags": [
+                    "Repository"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "repository",
+                        "in": "path",
+                        "required": true,
+                        "description": "The repository UUID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            }
+        },
+        "/organizations/{organization}/repositories/{repository}/sync": {
+            "post": {
+                "operationId": "v1.repositories.sync",
+                "tags": [
+                    "Repository"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "repository",
+                        "in": "path",
+                        "required": true,
+                        "description": "The repository UUID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "`RepositoryData`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RepositoryData"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            }
+        },
+        "/organizations/{organization}/tokens": {
+            "get": {
+                "operationId": "v1.tokens.index",
+                "tags": [
+                    "Token"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "`PaginatedDataCollection`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedDataCollection"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            },
+            "post": {
+                "operationId": "v1.tokens.store",
+                "tags": [
+                    "Token"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/StoreAccessTokenRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "`TokenCreatedData`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TokenCreatedData"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationException"
+                    }
+                }
+            }
+        },
+        "/organizations/{organization}/tokens/{token}": {
+            "patch": {
+                "operationId": "v1.tokens.update",
+                "tags": [
+                    "Token"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "required": true,
+                        "description": "The token UUID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateAccessTokenRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "`AccessTokenData`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AccessTokenData"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationException"
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "v1.tokens.destroy",
+                "tags": [
+                    "Token"
+                ],
+                "parameters": [
+                    {
+                        "name": "organization",
+                        "in": "path",
+                        "required": true,
+                        "description": "The organization slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "required": true,
+                        "description": "The token UUID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/AuthorizationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            }
+        },
+        "/user": {
+            "get": {
+                "operationId": "v1.user.show",
+                "summary": "Get the authenticated user's profile",
+                "tags": [
+                    "User"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "uuid": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "email": {
+                                            "type": "string"
+                                        },
+                                        "avatar": {
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "uuid",
+                                        "name",
+                                        "email",
+                                        "avatar"
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/user/organizations": {
+            "get": {
+                "operationId": "v1.user.organizations",
+                "summary": "List the organizations the authenticated user belongs to",
+                "tags": [
+                    "User"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "`PaginatedDataCollection`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedDataCollection"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/user/tokens": {
+            "get": {
+                "operationId": "v1.user.tokens.index",
+                "tags": [
+                    "UserToken"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "`PaginatedDataCollection`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedDataCollection"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "operationId": "v1.user.tokens.store",
+                "tags": [
+                    "UserToken"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/StoreAccessTokenRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "`TokenCreatedData`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TokenCreatedData"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationException"
+                    }
+                }
+            }
+        },
+        "/user/tokens/{token}": {
+            "patch": {
+                "operationId": "v1.user.tokens.update",
+                "tags": [
+                    "UserToken"
+                ],
+                "parameters": [
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "required": true,
+                        "description": "The token UUID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateAccessTokenRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "`AccessTokenData`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AccessTokenData"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationException"
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "v1.user.tokens.destroy",
+                "tags": [
+                    "UserToken"
+                ],
+                "parameters": [
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "required": true,
+                        "description": "The token UUID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "securitySchemes": {
+            "http": {
+                "type": "http",
+                "scheme": "bearer"
+            }
+        },
+        "schemas": {
+            "AccessTokenData": {
+                "type": "object",
+                "additionalProperties": {},
+                "title": "AccessTokenData"
+            },
+            "AddMemberRequest": {
+                "type": "object",
+                "properties": {
+                    "email": {
+                        "type": "string",
+                        "format": "email"
+                    },
+                    "role": {
+                        "type": "string",
+                        "enum": [
+                            "admin",
+                            "member"
+                        ]
+                    }
+                },
+                "required": [
+                    "email",
+                    "role"
+                ],
+                "title": "AddMemberRequest"
+            },
+            "BulkImportResultData": {
+                "type": "object",
+                "additionalProperties": {},
+                "title": "BulkImportResultData"
+            },
+            "BulkStoreRepositoryRequest": {
+                "type": "object",
+                "properties": {
+                    "provider": {
+                        "$ref": "#/components/schemas/GitProvider"
+                    },
+                    "repositories": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "repo_identifier": {
+                                    "type": "string",
+                                    "maxLength": 500
+                                }
+                            },
+                            "required": [
+                                "repo_identifier"
+                            ]
+                        },
+                        "minItems": 1,
+                        "maxItems": 50
+                    }
+                },
+                "required": [
+                    "provider",
+                    "repositories"
+                ],
+                "title": "BulkStoreRepositoryRequest"
+            },
+            "GitProvider": {
+                "type": "string",
+                "enum": [
+                    "github",
+                    "gitlab",
+                    "bitbucket",
+                    "git"
+                ],
+                "title": "GitProvider"
+            },
+            "MirrorAuthType": {
+                "type": "string",
+                "enum": [
+                    "none",
+                    "basic",
+                    "bearer"
+                ],
+                "title": "MirrorAuthType"
+            },
+            "MirrorData": {
+                "type": "object",
+                "additionalProperties": {},
+                "title": "MirrorData"
+            },
+            "OrganizationData": {
+                "type": "object",
+                "additionalProperties": {},
+                "title": "OrganizationData"
+            },
+            "OrganizationInvitationData": {
+                "type": "object",
+                "additionalProperties": {},
+                "title": "OrganizationInvitationData"
+            },
+            "OrganizationMemberData": {
+                "type": "object",
+                "additionalProperties": {},
+                "title": "OrganizationMemberData"
+            },
+            "PackageData": {
+                "type": "object",
+                "additionalProperties": {},
+                "title": "PackageData"
+            },
+            "PaginatedDataCollection": {
+                "type": "object",
+                "additionalProperties": {},
+                "title": "PaginatedDataCollection"
+            },
+            "RepositoryData": {
+                "type": "object",
+                "additionalProperties": {},
+                "title": "RepositoryData"
+            },
+            "StoreAccessTokenRequest": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "expires_at": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "scopes": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "$ref": "#/components/schemas/TokenScope"
+                        }
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "title": "StoreAccessTokenRequest"
+            },
+            "StoreMirrorRequest": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "maxLength": 2048
+                    },
+                    "auth_type": {
+                        "$ref": "#/components/schemas/MirrorAuthType"
+                    },
+                    "username": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "maxLength": 255
+                    },
+                    "password": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "maxLength": 1024
+                    },
+                    "token": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "maxLength": 1024
+                    },
+                    "mirror_dist": {
+                        "type": "boolean"
+                    }
+                },
+                "required": [
+                    "name",
+                    "url",
+                    "auth_type"
+                ],
+                "title": "StoreMirrorRequest"
+            },
+            "StoreOrganizationRequest": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "title": "StoreOrganizationRequest"
+            },
+            "StoreRepositoryRequest": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "maxLength": 255
+                    },
+                    "provider": {
+                        "$ref": "#/components/schemas/GitProvider"
+                    },
+                    "repo_identifier": {
+                        "type": "string",
+                        "maxLength": 500
+                    },
+                    "default_branch": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "maxLength": 255
+                    },
+                    "ssh_key_uuid": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uuid"
+                    }
+                },
+                "required": [
+                    "provider",
+                    "repo_identifier"
+                ],
+                "title": "StoreRepositoryRequest"
+            },
+            "TokenCreatedData": {
+                "type": "object",
+                "additionalProperties": {},
+                "title": "TokenCreatedData"
+            },
+            "TokenScope": {
+                "type": "string",
+                "enum": [
+                    "composer",
+                    "read:organizations",
+                    "write:organizations",
+                    "delete:organizations",
+                    "read:repositories",
+                    "write:repositories",
+                    "delete:repositories",
+                    "read:packages",
+                    "write:packages",
+                    "delete:packages",
+                    "read:members",
+                    "write:members",
+                    "read:mirrors",
+                    "write:mirrors",
+                    "delete:mirrors",
+                    "read:tokens",
+                    "write:tokens"
+                ],
+                "title": "TokenScope"
+            },
+            "UpdateAccessTokenRequest": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "scopes": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "$ref": "#/components/schemas/TokenScope"
+                        }
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "title": "UpdateAccessTokenRequest"
+            },
+            "UpdateMemberRoleRequest": {
+                "type": "object",
+                "properties": {
+                    "role": {
+                        "type": "string",
+                        "enum": [
+                            "admin",
+                            "member"
+                        ]
+                    }
+                },
+                "required": [
+                    "role"
+                ],
+                "title": "UpdateMemberRoleRequest"
+            },
+            "UpdateOrganizationRequest": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "title": "UpdateOrganizationRequest"
+            }
+        },
+        "responses": {
+            "ValidationException": {
+                "description": "Validation error",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "message": {
+                                    "type": "string",
+                                    "description": "Errors overview."
+                                },
+                                "errors": {
+                                    "type": "object",
+                                    "description": "A detailed description of each field that failed validation.",
+                                    "additionalProperties": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "required": [
+                                "message",
+                                "errors"
+                            ]
+                        }
+                    }
+                }
+            },
+            "ModelNotFoundException": {
+                "description": "Not found",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "message": {
+                                    "type": "string",
+                                    "description": "Error overview."
+                                }
+                            },
+                            "required": [
+                                "message"
+                            ]
+                        }
+                    }
+                }
+            },
+            "AuthorizationException": {
+                "description": "Authorization error",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "message": {
+                                    "type": "string",
+                                    "description": "Error overview."
+                                }
+                            },
+                            "required": [
+                                "message"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/resources/js/components/create-token-dialog.tsx
+++ b/resources/js/components/create-token-dialog.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
     Dialog,
     DialogContent,
@@ -16,7 +17,10 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
+import { API_SCOPE_GROUPS } from '@/lib/token-scopes';
 import { Form } from '@inertiajs/react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
 
 interface CreateTokenDialogProps {
     storeUrl: string;
@@ -31,15 +35,17 @@ export default function CreateTokenDialog({
     isOpen,
     onClose,
 }: CreateTokenDialogProps) {
+    const [showApiScopes, setShowApiScopes] = useState(false);
+
     return (
         <Dialog open={isOpen} onOpenChange={onClose}>
-            <DialogContent>
+            <DialogContent className="max-h-[90vh] overflow-y-auto">
                 <DialogHeader>
                     <DialogTitle>Create Access Token</DialogTitle>
                     <DialogDescription>{description}</DialogDescription>
                 </DialogHeader>
 
-                <Form action={storeUrl} method="post" className="space-y-4">
+                <Form action={storeUrl} method="post" className="space-y-5">
                     {({ processing, errors }) => (
                         <>
                             <div className="grid space-y-2">
@@ -51,7 +57,7 @@ export default function CreateTokenDialog({
                                     id="name"
                                     name="name"
                                     required
-                                    placeholder="My API Token"
+                                    placeholder="e.g. Production server"
                                     autoFocus
                                 />
                                 {errors.name && (
@@ -88,6 +94,90 @@ export default function CreateTokenDialog({
                                     <p className="text-destructive">
                                         {errors.expires_at}
                                     </p>
+                                )}
+                            </div>
+
+                            {/* Every token can install packages with Composer. */}
+                            <input
+                                type="hidden"
+                                name="scopes[]"
+                                value="composer"
+                            />
+
+                            <div className="rounded-md border">
+                                <button
+                                    type="button"
+                                    onClick={() => setShowApiScopes((v) => !v)}
+                                    className="flex w-full items-center justify-between gap-3 p-3 text-left"
+                                    aria-expanded={showApiScopes}
+                                >
+                                    <span>
+                                        <span className="text-sm font-medium">
+                                            API access
+                                        </span>
+                                        <span className="mt-0.5 block text-sm text-muted-foreground">
+                                            Optional — let this token automate
+                                            Pricore through the REST API.
+                                        </span>
+                                    </span>
+                                    {showApiScopes ? (
+                                        <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+                                    ) : (
+                                        <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+                                    )}
+                                </button>
+
+                                {showApiScopes && (
+                                    <div className="grid gap-3 border-t p-3">
+                                        <p className="text-sm text-muted-foreground">
+                                            Pick the permissions this token
+                                            needs. It can never exceed your own
+                                            access.
+                                        </p>
+                                        {API_SCOPE_GROUPS.map((group) => (
+                                            <div
+                                                key={group.label}
+                                                className="grid space-y-1.5"
+                                            >
+                                                <span className="text-xs font-medium text-muted-foreground">
+                                                    {group.label}
+                                                </span>
+                                                <div className="flex flex-wrap gap-x-4 gap-y-2">
+                                                    {group.scopes.map(
+                                                        (scope) => (
+                                                            <div
+                                                                key={
+                                                                    scope.value
+                                                                }
+                                                                className="flex items-center gap-2"
+                                                            >
+                                                                <Checkbox
+                                                                    id={`scope-${scope.value}`}
+                                                                    name="scopes[]"
+                                                                    value={
+                                                                        scope.value
+                                                                    }
+                                                                />
+                                                                <Label
+                                                                    htmlFor={`scope-${scope.value}`}
+                                                                    className="font-normal"
+                                                                >
+                                                                    {
+                                                                        scope.label
+                                                                    }
+                                                                </Label>
+                                                            </div>
+                                                        ),
+                                                    )}
+                                                </div>
+                                            </div>
+                                        ))}
+                                        {errors.scopes && (
+                                            <p className="text-destructive">
+                                                {errors.scopes}
+                                            </p>
+                                        )}
+                                    </div>
                                 )}
                             </div>
 

--- a/resources/js/components/edit-token-dialog.tsx
+++ b/resources/js/components/edit-token-dialog.tsx
@@ -1,0 +1,174 @@
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { API_SCOPE_GROUPS } from '@/lib/token-scopes';
+import { Form } from '@inertiajs/react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
+
+type AccessTokenData = App.Domains.Token.Contracts.Data.AccessTokenData;
+
+interface EditTokenDialogProps {
+    updateUrl: string;
+    token: AccessTokenData;
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+export default function EditTokenDialog({
+    updateUrl,
+    token,
+    isOpen,
+    onClose,
+}: EditTokenDialogProps) {
+    const hasApiScopes = token.scopes.some((scope) => scope !== 'composer');
+    const [showApiScopes, setShowApiScopes] = useState(hasApiScopes);
+
+    return (
+        <Dialog open={isOpen} onOpenChange={onClose}>
+            <DialogContent className="max-h-[90vh] overflow-y-auto">
+                <DialogHeader>
+                    <DialogTitle>Edit Token</DialogTitle>
+                    <DialogDescription>
+                        Change the name and permissions. The token value itself
+                        stays the same.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <Form action={updateUrl} method="patch" className="space-y-5">
+                    {({ processing, errors }) => (
+                        <>
+                            <div className="grid space-y-2">
+                                <Label htmlFor="name">
+                                    Token Name{' '}
+                                    <span className="text-red-500">*</span>
+                                </Label>
+                                <Input
+                                    id="name"
+                                    name="name"
+                                    required
+                                    defaultValue={token.name}
+                                    autoFocus
+                                />
+                                {errors.name && (
+                                    <p className="text-destructive">
+                                        {errors.name}
+                                    </p>
+                                )}
+                            </div>
+
+                            {/* Every token can install packages with Composer. */}
+                            <input
+                                type="hidden"
+                                name="scopes[]"
+                                value="composer"
+                            />
+
+                            <div className="rounded-md border">
+                                <button
+                                    type="button"
+                                    onClick={() => setShowApiScopes((v) => !v)}
+                                    className="flex w-full items-center justify-between gap-3 p-3 text-left"
+                                    aria-expanded={showApiScopes}
+                                >
+                                    <span>
+                                        <span className="text-sm font-medium">
+                                            API access
+                                        </span>
+                                        <span className="mt-0.5 block text-sm text-muted-foreground">
+                                            Optional — let this token automate
+                                            Pricore through the REST API.
+                                        </span>
+                                    </span>
+                                    {showApiScopes ? (
+                                        <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+                                    ) : (
+                                        <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+                                    )}
+                                </button>
+
+                                {showApiScopes && (
+                                    <div className="grid gap-3 border-t p-3">
+                                        <p className="text-sm text-muted-foreground">
+                                            Pick the permissions this token
+                                            needs. It can never exceed your own
+                                            access.
+                                        </p>
+                                        {API_SCOPE_GROUPS.map((group) => (
+                                            <div
+                                                key={group.label}
+                                                className="grid space-y-1.5"
+                                            >
+                                                <span className="text-xs font-medium text-muted-foreground">
+                                                    {group.label}
+                                                </span>
+                                                <div className="flex flex-wrap gap-x-4 gap-y-2">
+                                                    {group.scopes.map(
+                                                        (scope) => (
+                                                            <div
+                                                                key={
+                                                                    scope.value
+                                                                }
+                                                                className="flex items-center gap-2"
+                                                            >
+                                                                <Checkbox
+                                                                    id={`edit-scope-${scope.value}`}
+                                                                    name="scopes[]"
+                                                                    value={
+                                                                        scope.value
+                                                                    }
+                                                                    defaultChecked={token.scopes.includes(
+                                                                        scope.value,
+                                                                    )}
+                                                                />
+                                                                <Label
+                                                                    htmlFor={`edit-scope-${scope.value}`}
+                                                                    className="font-normal"
+                                                                >
+                                                                    {
+                                                                        scope.label
+                                                                    }
+                                                                </Label>
+                                                            </div>
+                                                        ),
+                                                    )}
+                                                </div>
+                                            </div>
+                                        ))}
+                                        {errors.scopes && (
+                                            <p className="text-destructive">
+                                                {errors.scopes}
+                                            </p>
+                                        )}
+                                    </div>
+                                )}
+                            </div>
+
+                            <DialogFooter>
+                                <Button
+                                    type="button"
+                                    variant="secondary"
+                                    onClick={onClose}
+                                >
+                                    Cancel
+                                </Button>
+                                <Button type="submit" disabled={processing}>
+                                    {processing ? 'Saving...' : 'Save Changes'}
+                                </Button>
+                            </DialogFooter>
+                        </>
+                    )}
+                </Form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/resources/js/components/token-created-dialog.tsx
+++ b/resources/js/components/token-created-dialog.tsx
@@ -15,6 +15,7 @@ interface TokenCreatedDialogProps {
     token: string;
     name: string;
     expiresAt: string | null;
+    scopes: string[];
     isOpen: boolean;
     onClose: () => void;
 }
@@ -23,19 +24,16 @@ export default function TokenCreatedDialog({
     token,
     name,
     expiresAt,
+    scopes,
     isOpen,
     onClose,
 }: TokenCreatedDialogProps) {
-    const [copiedToken, setCopiedToken] = useState(false);
-    const [copiedComposer, setCopiedComposer] = useState(false);
+    const [copied, setCopied] = useState<string | null>(null);
     const inputRef = useRef<HTMLInputElement>(null);
 
-    const copyToClipboard = async (
-        text: string,
-        type: 'token' | 'composer',
-    ) => {
+    const copyToClipboard = async (text: string, key: string) => {
         try {
-            if (type === 'token' && inputRef.current) {
+            if (key === 'token' && inputRef.current) {
                 inputRef.current.focus();
                 inputRef.current.select();
             }
@@ -55,10 +53,8 @@ export default function TokenCreatedDialog({
                 textArea.remove();
             }
 
-            const setCopied =
-                type === 'token' ? setCopiedToken : setCopiedComposer;
-            setCopied(true);
-            setTimeout(() => setCopied(false), 2000);
+            setCopied(key);
+            setTimeout(() => setCopied(null), 2000);
         } catch (error) {
             console.error('Failed to copy:', error);
         }
@@ -66,9 +62,18 @@ export default function TokenCreatedDialog({
 
     const domain = window.location.host;
 
+    // A legacy token with no recorded scopes can do everything.
+    const grantsEverything = scopes.length === 0;
+    const hasComposer = grantsEverything || scopes.includes('composer');
+    const hasApi =
+        grantsEverything || scopes.some((scope) => scope !== 'composer');
+
+    const composerCommand = `composer config --global --auth http-basic.${domain} token ${token}`;
+    const apiCommand = `curl -H "Authorization: Bearer ${token}" \\\n     -H "Accept: application/json" \\\n     https://${domain}/api/v1/user`;
+
     return (
         <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-            <DialogContent className="max-w-lg">
+            <DialogContent className="max-h-[90vh] max-w-lg overflow-y-auto">
                 <DialogHeader>
                     <DialogTitle>Access Token Created</DialogTitle>
                     <DialogDescription>
@@ -110,7 +115,7 @@ export default function TokenCreatedDialog({
                                 onClick={() => copyToClipboard(token, 'token')}
                                 className="shrink-0"
                             >
-                                {copiedToken ? (
+                                {copied === 'token' ? (
                                     <Check className="h-4 w-4" />
                                 ) : (
                                     <Copy className="h-4 w-4" />
@@ -119,38 +124,79 @@ export default function TokenCreatedDialog({
                         </div>
                     </div>
 
-                    <div className="rounded-md border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950">
-                        <p className="font-medium text-neutral-900 dark:text-neutral-100">
-                            Configure Composer
-                        </p>
-                        <p className="mt-1 text-neutral-700 dark:text-neutral-300">
-                            Use this token to authenticate with Composer:
-                        </p>
-                        <div className="mt-2 flex items-start gap-2">
-                            <code className="min-w-0 flex-1 rounded border border-border bg-muted p-2 font-mono text-xs break-all">
-                                composer config --global --auth http-basic.
-                                {domain} token {token}
-                            </code>
-                            <Button
-                                type="button"
-                                variant="secondary"
-                                size="icon"
-                                onClick={() =>
-                                    copyToClipboard(
-                                        `composer config --global --auth http-basic.${domain} token ${token}`,
-                                        'composer',
-                                    )
-                                }
-                                className="shrink-0"
-                            >
-                                {copiedComposer ? (
-                                    <Check className="h-4 w-4" />
-                                ) : (
-                                    <Copy className="h-4 w-4" />
-                                )}
-                            </Button>
+                    {hasComposer && (
+                        <div className="rounded-md border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950">
+                            <p className="font-medium text-neutral-900 dark:text-neutral-100">
+                                Configure Composer
+                            </p>
+                            <p className="mt-1 text-neutral-700 dark:text-neutral-300">
+                                Use this token to authenticate with Composer:
+                            </p>
+                            <div className="mt-2 flex items-start gap-2">
+                                <code className="min-w-0 flex-1 rounded border border-border bg-muted p-2 font-mono text-xs break-all">
+                                    {composerCommand}
+                                </code>
+                                <Button
+                                    type="button"
+                                    variant="secondary"
+                                    size="icon"
+                                    onClick={() =>
+                                        copyToClipboard(
+                                            composerCommand,
+                                            'composer',
+                                        )
+                                    }
+                                    className="shrink-0"
+                                >
+                                    {copied === 'composer' ? (
+                                        <Check className="h-4 w-4" />
+                                    ) : (
+                                        <Copy className="h-4 w-4" />
+                                    )}
+                                </Button>
+                            </div>
                         </div>
-                    </div>
+                    )}
+
+                    {hasApi && (
+                        <div className="rounded-md border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950">
+                            <p className="font-medium text-neutral-900 dark:text-neutral-100">
+                                Use the API
+                            </p>
+                            <p className="mt-1 text-neutral-700 dark:text-neutral-300">
+                                Send the token as a Bearer header. See the{' '}
+                                <a
+                                    href="/docs/api"
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="underline underline-offset-2"
+                                >
+                                    API reference
+                                </a>
+                                .
+                            </p>
+                            <div className="mt-2 flex items-start gap-2">
+                                <code className="min-w-0 flex-1 rounded border border-border bg-muted p-2 font-mono text-xs break-all whitespace-pre-wrap">
+                                    {apiCommand}
+                                </code>
+                                <Button
+                                    type="button"
+                                    variant="secondary"
+                                    size="icon"
+                                    onClick={() =>
+                                        copyToClipboard(apiCommand, 'api')
+                                    }
+                                    className="shrink-0"
+                                >
+                                    {copied === 'api' ? (
+                                        <Check className="h-4 w-4" />
+                                    ) : (
+                                        <Copy className="h-4 w-4" />
+                                    )}
+                                </Button>
+                            </div>
+                        </div>
+                    )}
                 </div>
 
                 <DialogFooter>

--- a/resources/js/components/token-list.tsx
+++ b/resources/js/components/token-list.tsx
@@ -1,17 +1,22 @@
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
-import { Trash2 } from 'lucide-react';
+import { Pencil, Trash2 } from 'lucide-react';
 import { DateTime } from 'luxon';
 
 type AccessTokenData = App.Domains.Token.Contracts.Data.AccessTokenData;
 
 interface TokenListProps {
     tokens: AccessTokenData[];
+    onEdit: (token: AccessTokenData) => void;
     onRevoke: (uuid: string, name: string) => void;
 }
 
-export default function TokenList({ tokens, onRevoke }: TokenListProps) {
+export default function TokenList({
+    tokens,
+    onEdit,
+    onRevoke,
+}: TokenListProps) {
     if (tokens.length === 0) {
         return (
             <div className="my-2 rounded-lg border border-dashed p-8 text-center">
@@ -35,6 +40,7 @@ export default function TokenList({ tokens, onRevoke }: TokenListProps) {
                                     <Badge variant="destructive">Expired</Badge>
                                 )}
                             </div>
+                            <ScopeBadges scopes={token.scopes} />
                             <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-sm text-muted-foreground">
                                 <span>
                                     Last used:{' '}
@@ -60,14 +66,24 @@ export default function TokenList({ tokens, onRevoke }: TokenListProps) {
                                 </span>
                             </div>
                         </div>
-                        <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={() => onRevoke(token.uuid, token.name)}
-                            aria-label={`Revoke ${token.name}`}
-                        >
-                            <Trash2 className="h-4 w-4" />
-                        </Button>
+                        <div className="flex items-center gap-1">
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => onEdit(token)}
+                                aria-label={`Edit ${token.name}`}
+                            >
+                                <Pencil className="h-4 w-4" />
+                            </Button>
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => onRevoke(token.uuid, token.name)}
+                                aria-label={`Revoke ${token.name}`}
+                            >
+                                <Trash2 className="h-4 w-4" />
+                            </Button>
+                        </div>
                     </div>
                 </div>
             ))}
@@ -78,4 +94,38 @@ export default function TokenList({ tokens, onRevoke }: TokenListProps) {
 function isTokenExpired(expiresAt: string | null): boolean {
     if (!expiresAt) return false;
     return new Date(expiresAt) < new Date();
+}
+
+// Composer access is the baseline for every token, so only surface the
+// additional API permissions (if any) to keep the list uncluttered.
+function ScopeBadges({ scopes }: { scopes: string[] }) {
+    if (scopes.length === 0) {
+        return (
+            <div className="flex flex-wrap gap-1 pt-0.5">
+                <Badge variant="outline" className="text-xs font-normal">
+                    Full access
+                </Badge>
+            </div>
+        );
+    }
+
+    const apiScopes = scopes.filter((scope) => scope !== 'composer');
+
+    if (apiScopes.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="flex flex-wrap gap-1 pt-0.5">
+            {apiScopes.map((scope) => (
+                <Badge
+                    key={scope}
+                    variant="secondary"
+                    className="font-mono text-xs font-normal"
+                >
+                    {scope}
+                </Badge>
+            ))}
+        </div>
+    );
 }

--- a/resources/js/layouts/organization-settings-layout.tsx
+++ b/resources/js/layouts/organization-settings-layout.tsx
@@ -56,7 +56,7 @@ function SettingsContent({ children }: PropsWithChildren) {
                 label: 'Registry',
                 items: [
                     {
-                        title: 'Composer Tokens',
+                        title: 'Access Tokens',
                         href: `${base}/tokens`,
                         icon: Key,
                     },
@@ -177,7 +177,7 @@ function SettingsContent({ children }: PropsWithChildren) {
 const settingsPageTitles: Record<string, string> = {
     general: 'General',
     members: 'Members',
-    tokens: 'Composer Tokens',
+    tokens: 'Access Tokens',
     'ssh-keys': 'SSH Keys',
     mirrors: 'Registry Mirrors',
     security: 'Security',

--- a/resources/js/layouts/settings/layout.tsx
+++ b/resources/js/layouts/settings/layout.tsx
@@ -47,7 +47,7 @@ const sidebarNavItems: NavItem[] = [
         icon: GitBranch,
     },
     {
-        title: 'Tokens',
+        title: 'Access Tokens',
         href: tokensIndex(),
         icon: Key,
     },

--- a/resources/js/lib/token-scopes.ts
+++ b/resources/js/lib/token-scopes.ts
@@ -1,0 +1,57 @@
+type TokenScope = App.Domains.Token.Contracts.Enums.TokenScope;
+
+export interface ScopeGroup {
+    label: string;
+    scopes: { value: TokenScope; label: string }[];
+}
+
+// Composer access is granted to every token implicitly; these are the
+// additional, opt-in permissions for the management API.
+export const API_SCOPE_GROUPS: ScopeGroup[] = [
+    {
+        label: 'Organizations',
+        scopes: [
+            { value: 'read:organizations', label: 'Read' },
+            { value: 'write:organizations', label: 'Write' },
+            { value: 'delete:organizations', label: 'Delete' },
+        ],
+    },
+    {
+        label: 'Repositories',
+        scopes: [
+            { value: 'read:repositories', label: 'Read' },
+            { value: 'write:repositories', label: 'Write' },
+            { value: 'delete:repositories', label: 'Delete' },
+        ],
+    },
+    {
+        label: 'Packages',
+        scopes: [
+            { value: 'read:packages', label: 'Read' },
+            { value: 'write:packages', label: 'Write' },
+            { value: 'delete:packages', label: 'Delete' },
+        ],
+    },
+    {
+        label: 'Members',
+        scopes: [
+            { value: 'read:members', label: 'Read' },
+            { value: 'write:members', label: 'Write' },
+        ],
+    },
+    {
+        label: 'Mirrors',
+        scopes: [
+            { value: 'read:mirrors', label: 'Read' },
+            { value: 'write:mirrors', label: 'Write' },
+            { value: 'delete:mirrors', label: 'Delete' },
+        ],
+    },
+    {
+        label: 'Tokens',
+        scopes: [
+            { value: 'read:tokens', label: 'Read' },
+            { value: 'write:tokens', label: 'Write' },
+        ],
+    },
+];

--- a/resources/js/pages/organizations/settings/tokens.tsx
+++ b/resources/js/pages/organizations/settings/tokens.tsx
@@ -1,9 +1,11 @@
 import {
     destroy,
     store,
+    update,
 } from '@/actions/App/Domains/Token/Http/Controllers/TokenController';
 import { CopyButton } from '@/components/copy-button';
 import CreateTokenDialog from '@/components/create-token-dialog';
+import EditTokenDialog from '@/components/edit-token-dialog';
 import InfoBox from '@/components/info-box';
 import RevokeTokenDialog from '@/components/revoke-token-dialog';
 import TokenCreatedDialog from '@/components/token-created-dialog';
@@ -31,6 +33,10 @@ export default function Tokens({
 }: TokensPageProps) {
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
     const [revokeDialogOpen, setRevokeDialogOpen] = useState(false);
+    const [editDialogOpen, setEditDialogOpen] = useState(false);
+    const [editingToken, setEditingToken] = useState<AccessTokenData | null>(
+        null,
+    );
     const [tokenCreatedDialogOpen, setTokenCreatedDialogOpen] =
         useState(!!tokenCreated);
     const [selectedToken, setSelectedToken] = useState<{
@@ -68,15 +74,21 @@ export default function Tokens({
         setRevokeDialogOpen(true);
     };
 
+    const handleEdit = (token: AccessTokenData) => {
+        setEditingToken(token);
+        setEditDialogOpen(true);
+    };
+
     const composerRepoCommand = `composer config repositories.${organization.slug} composer ${organization.composerRepositoryUrl}`;
 
     return (
         <div className="space-y-6">
             <div className="flex items-center justify-between">
                 <div>
-                    <h3 className="text-lg font-medium">Composer Tokens</h3>
+                    <h3 className="text-lg font-medium">Access Tokens</h3>
                     <p className="text-muted-foreground">
-                        Manage access tokens for Composer authentication
+                        Shared tokens for this organization's packages and
+                        automation
                     </p>
                 </div>
                 <Button onClick={() => setCreateDialogOpen(true)}>
@@ -102,20 +114,39 @@ export default function Tokens({
             </div>
 
             <div className="rounded-lg border bg-card px-4 py-2">
-                <TokenList tokens={tokens} onRevoke={handleRevoke} />
+                <TokenList
+                    tokens={tokens}
+                    onEdit={handleEdit}
+                    onRevoke={handleRevoke}
+                />
             </div>
 
             <InfoBox
                 title="About Organization Tokens"
-                description="Organization tokens grant access to packages within this organization only. Each token can be configured with an expiration date for security. For tokens that work across all your organizations, visit your personal token settings."
+                description={`Organization tokens belong to ${organization.name} and are shared by everyone who can manage its settings — ideal for CI pipelines and servers, and they keep working after a member leaves. They install this organization's packages with Composer and can act on it through the Pricore API. For a token tied to you personally and usable across all your organizations, use your personal access tokens.`}
             />
 
             <CreateTokenDialog
                 storeUrl={store.url(organization.slug)}
-                description="Create a new token for access to this organization's packages."
+                description={`A shared token for the ${organization.name} organization.`}
                 isOpen={createDialogOpen}
                 onClose={() => setCreateDialogOpen(false)}
             />
+
+            {editingToken && (
+                <EditTokenDialog
+                    updateUrl={update.url([
+                        organization.slug,
+                        editingToken.uuid,
+                    ])}
+                    token={editingToken}
+                    isOpen={editDialogOpen}
+                    onClose={() => {
+                        setEditDialogOpen(false);
+                        setEditingToken(null);
+                    }}
+                />
+            )}
 
             {selectedToken && (
                 <RevokeTokenDialog
@@ -137,6 +168,7 @@ export default function Tokens({
                     token={tokenCreated.plainToken}
                     name={tokenCreated.name}
                     expiresAt={tokenCreated.expiresAt}
+                    scopes={tokenCreated.scopes}
                     isOpen={tokenCreatedDialogOpen}
                     onClose={() => setTokenCreatedDialogOpen(false)}
                 />

--- a/resources/js/pages/settings/tokens.tsx
+++ b/resources/js/pages/settings/tokens.tsx
@@ -1,8 +1,10 @@
 import {
     destroy,
     store,
+    update,
 } from '@/actions/App/Domains/Token/Http/Controllers/UserTokenController';
 import CreateTokenDialog from '@/components/create-token-dialog';
+import EditTokenDialog from '@/components/edit-token-dialog';
 import InfoBox from '@/components/info-box';
 import RevokeTokenDialog from '@/components/revoke-token-dialog';
 import TokenCreatedDialog from '@/components/token-created-dialog';
@@ -30,7 +32,7 @@ const breadcrumbs: BreadcrumbItem[] = [
         href: editProfile().url,
     },
     {
-        title: 'Tokens',
+        title: 'Access Tokens',
         href: tokensIndex().url,
     },
 ];
@@ -38,6 +40,10 @@ const breadcrumbs: BreadcrumbItem[] = [
 export default function Tokens({ tokens, tokenCreated }: TokensPageProps) {
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
     const [revokeDialogOpen, setRevokeDialogOpen] = useState(false);
+    const [editDialogOpen, setEditDialogOpen] = useState(false);
+    const [editingToken, setEditingToken] = useState<AccessTokenData | null>(
+        null,
+    );
     const [tokenCreatedDialogOpen, setTokenCreatedDialogOpen] =
         useState(!!tokenCreated);
     const [selectedToken, setSelectedToken] = useState<{
@@ -75,6 +81,11 @@ export default function Tokens({ tokens, tokenCreated }: TokensPageProps) {
         setRevokeDialogOpen(true);
     };
 
+    const handleEdit = (token: AccessTokenData) => {
+        setEditingToken(token);
+        setEditDialogOpen(true);
+    };
+
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <SettingsLayout>
@@ -82,11 +93,11 @@ export default function Tokens({ tokens, tokenCreated }: TokensPageProps) {
                     <div className="flex items-center justify-between">
                         <div>
                             <h3 className="text-lg font-medium">
-                                Personal Tokens
+                                Personal Access Tokens
                             </h3>
                             <p className="text-muted-foreground">
-                                Manage personal access tokens for Composer
-                                authentication
+                                Install packages with Composer across every
+                                organization you belong to
                             </p>
                         </div>
                         <Button onClick={() => setCreateDialogOpen(true)}>
@@ -96,20 +107,36 @@ export default function Tokens({ tokens, tokenCreated }: TokensPageProps) {
                     </div>
 
                     <div className="rounded-lg border bg-card px-4 py-2">
-                        <TokenList tokens={tokens} onRevoke={handleRevoke} />
+                        <TokenList
+                            tokens={tokens}
+                            onEdit={handleEdit}
+                            onRevoke={handleRevoke}
+                        />
                     </div>
 
                     <InfoBox
-                        title="About Personal Tokens"
-                        description="Personal tokens grant access to packages across all organizations you belong to. For tokens scoped to a single organization, visit that organization's token settings."
+                        title="About Personal Access Tokens"
+                        description="Personal tokens act as you across every organization you belong to — for installing packages with Composer and for the Pricore API. For a token limited to a single organization, visit that organization's token settings."
                     />
 
                     <CreateTokenDialog
                         storeUrl={store.url()}
-                        description="Create a personal token that grants access to packages across all your organizations."
+                        description="Acts as you across every organization you belong to."
                         isOpen={createDialogOpen}
                         onClose={() => setCreateDialogOpen(false)}
                     />
+
+                    {editingToken && (
+                        <EditTokenDialog
+                            updateUrl={update.url(editingToken.uuid)}
+                            token={editingToken}
+                            isOpen={editDialogOpen}
+                            onClose={() => {
+                                setEditDialogOpen(false);
+                                setEditingToken(null);
+                            }}
+                        />
+                    )}
 
                     {selectedToken && (
                         <RevokeTokenDialog
@@ -128,6 +155,7 @@ export default function Tokens({ tokens, tokenCreated }: TokensPageProps) {
                             token={tokenCreated.plainToken}
                             name={tokenCreated.name}
                             expiresAt={tokenCreated.expiresAt}
+                            scopes={tokenCreated.scopes}
                             isOpen={tokenCreatedDialogOpen}
                             onClose={() => setTokenCreatedDialogOpen(false)}
                         />

--- a/resources/types/generated.d.ts
+++ b/resources/types/generated.d.ts
@@ -14,7 +14,7 @@ createdAt: string | null;
 };
 }
 declare namespace App.Domains.Activity.Contracts.Enums {
-export type ActivityType = 'repository.added' | 'repository.removed' | 'repository.synced' | 'repository.sync_failed' | 'package.created' | 'package.removed' | 'member.added' | 'member.removed' | 'member.role_changed' | 'invitation.sent' | 'token.created' | 'token.revoked' | 'ssh_key.generated' | 'ssh_key.deleted' | 'mirror.added' | 'mirror.removed' | 'mirror.synced' | 'mirror.sync_failed' | 'security.vulnerabilities_detected';
+export type ActivityType = 'repository.added' | 'repository.removed' | 'repository.synced' | 'repository.sync_failed' | 'package.created' | 'package.removed' | 'member.added' | 'member.removed' | 'member.role_changed' | 'invitation.sent' | 'token.created' | 'token.updated' | 'token.revoked' | 'ssh_key.generated' | 'ssh_key.deleted' | 'mirror.added' | 'mirror.removed' | 'mirror.synced' | 'mirror.sync_failed' | 'security.vulnerabilities_detected';
 }
 declare namespace App.Domains.Auth.Contracts.Enums {
 export type GitHubOAuthIntent = 'login' | 'connect';
@@ -319,13 +319,18 @@ name: string;
 lastUsedAt: string | null;
 expiresAt: string | null;
 createdAt: string;
+scopes: Array<any>;
 };
 export type TokenCreatedData = {
 plainToken: string;
 name: string;
 expiresAt: string | null;
 organizationUuid: string | null;
+scopes: Array<any>;
 };
+}
+declare namespace App.Domains.Token.Contracts.Enums {
+export type TokenScope = 'composer' | 'read:organizations' | 'write:organizations' | 'delete:organizations' | 'read:repositories' | 'write:repositories' | 'delete:repositories' | 'read:packages' | 'write:packages' | 'delete:packages' | 'read:members' | 'write:members' | 'read:mirrors' | 'write:mirrors' | 'delete:mirrors' | 'read:tokens' | 'write:tokens';
 }
 declare namespace App.Http.Data {
 export type AuthData = {

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,113 @@
+<?php
+
+use App\Http\Controllers\Api\V1\InvitationController;
+use App\Http\Controllers\Api\V1\MemberController;
+use App\Http\Controllers\Api\V1\MirrorController;
+use App\Http\Controllers\Api\V1\OrganizationController;
+use App\Http\Controllers\Api\V1\PackageController;
+use App\Http\Controllers\Api\V1\PackageVersionController;
+use App\Http\Controllers\Api\V1\RepositoryController;
+use App\Http\Controllers\Api\V1\TokenController;
+use App\Http\Controllers\Api\V1\UserController;
+use App\Http\Controllers\Api\V1\UserTokenController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['api.token', 'throttle:api'])->group(function () {
+    // Authenticated user (personal access tokens only)
+    Route::get('user', [UserController::class, 'show'])->name('user.show');
+    Route::get('user/organizations', [UserController::class, 'organizations'])
+        ->middleware('scope:read:organizations')->name('user.organizations');
+
+    Route::get('user/tokens', [UserTokenController::class, 'index'])
+        ->middleware('scope:read:tokens')->name('user.tokens.index');
+    Route::post('user/tokens', [UserTokenController::class, 'store'])
+        ->middleware('scope:write:tokens')->name('user.tokens.store');
+    Route::patch('user/tokens/{token}', [UserTokenController::class, 'update'])
+        ->middleware('scope:write:tokens')->name('user.tokens.update');
+    Route::delete('user/tokens/{token}', [UserTokenController::class, 'destroy'])
+        ->middleware('scope:write:tokens')->name('user.tokens.destroy');
+
+    // Organizations (top level)
+    Route::get('organizations', [OrganizationController::class, 'index'])
+        ->middleware('scope:read:organizations')->name('organizations.index');
+    Route::post('organizations', [OrganizationController::class, 'store'])
+        ->middleware('scope:write:organizations')->name('organizations.store');
+
+    // Organization-scoped resources
+    Route::prefix('organizations/{organization:slug}')
+        ->middleware('organization.member')
+        ->group(function () {
+            Route::get('/', [OrganizationController::class, 'show'])
+                ->middleware('scope:read:organizations')->name('organizations.show');
+            Route::patch('/', [OrganizationController::class, 'update'])
+                ->middleware('scope:write:organizations')->name('organizations.update');
+            Route::delete('/', [OrganizationController::class, 'destroy'])
+                ->middleware('scope:delete:organizations')->name('organizations.destroy');
+
+            // Repositories
+            Route::get('repositories', [RepositoryController::class, 'index'])
+                ->middleware('scope:read:repositories')->name('repositories.index');
+            Route::post('repositories', [RepositoryController::class, 'store'])
+                ->middleware('scope:write:repositories')->name('repositories.store');
+            Route::post('repositories/bulk', [RepositoryController::class, 'bulkStore'])
+                ->middleware('scope:write:repositories')->name('repositories.bulk');
+            Route::get('repositories/{repository:uuid}', [RepositoryController::class, 'show'])
+                ->middleware('scope:read:repositories')->name('repositories.show');
+            Route::post('repositories/{repository:uuid}/sync', [RepositoryController::class, 'sync'])
+                ->middleware('scope:write:repositories')->name('repositories.sync');
+            Route::delete('repositories/{repository:uuid}', [RepositoryController::class, 'destroy'])
+                ->middleware('scope:delete:repositories')->name('repositories.destroy');
+
+            // Packages
+            Route::get('packages', [PackageController::class, 'index'])
+                ->middleware('scope:read:packages')->name('packages.index');
+            Route::get('packages/{package:uuid}', [PackageController::class, 'show'])
+                ->middleware('scope:read:packages')->name('packages.show');
+            Route::delete('packages/{package:uuid}', [PackageController::class, 'destroy'])
+                ->middleware('scope:delete:packages')->name('packages.destroy');
+            Route::get('packages/{package:uuid}/versions', [PackageVersionController::class, 'index'])
+                ->middleware('scope:read:packages')->name('packages.versions.index');
+            Route::delete('packages/{package:uuid}/versions/{version:uuid}', [PackageVersionController::class, 'destroy'])
+                ->middleware('scope:delete:packages')->name('packages.versions.destroy');
+
+            // Members
+            Route::get('members', [MemberController::class, 'index'])
+                ->middleware('scope:read:members')->name('members.index');
+            Route::post('members', [MemberController::class, 'store'])
+                ->middleware('scope:write:members')->name('members.store');
+            Route::patch('members/{member:uuid}', [MemberController::class, 'update'])
+                ->middleware('scope:write:members')->name('members.update');
+            Route::delete('members/{member:uuid}', [MemberController::class, 'destroy'])
+                ->middleware('scope:write:members')->name('members.destroy');
+
+            // Invitations
+            Route::get('invitations', [InvitationController::class, 'index'])
+                ->middleware('scope:read:members')->name('invitations.index');
+            Route::post('invitations/{invitation:uuid}/resend', [InvitationController::class, 'resend'])
+                ->middleware('scope:write:members')->name('invitations.resend');
+            Route::delete('invitations/{invitation:uuid}', [InvitationController::class, 'destroy'])
+                ->middleware('scope:write:members')->name('invitations.destroy');
+
+            // Access tokens (organization scoped)
+            Route::get('tokens', [TokenController::class, 'index'])
+                ->middleware('scope:read:tokens')->name('tokens.index');
+            Route::post('tokens', [TokenController::class, 'store'])
+                ->middleware('scope:write:tokens')->name('tokens.store');
+            Route::patch('tokens/{token}', [TokenController::class, 'update'])
+                ->middleware('scope:write:tokens')->name('tokens.update');
+            Route::delete('tokens/{token}', [TokenController::class, 'destroy'])
+                ->middleware('scope:write:tokens')->name('tokens.destroy');
+
+            // Mirrors
+            Route::get('mirrors', [MirrorController::class, 'index'])
+                ->middleware('scope:read:mirrors')->name('mirrors.index');
+            Route::post('mirrors', [MirrorController::class, 'store'])
+                ->middleware('scope:write:mirrors')->name('mirrors.store');
+            Route::get('mirrors/{mirror:uuid}', [MirrorController::class, 'show'])
+                ->middleware('scope:read:mirrors')->name('mirrors.show');
+            Route::post('mirrors/{mirror:uuid}/sync', [MirrorController::class, 'sync'])
+                ->middleware('scope:write:mirrors')->name('mirrors.sync');
+            Route::delete('mirrors/{mirror:uuid}', [MirrorController::class, 'destroy'])
+                ->middleware('scope:delete:mirrors')->name('mirrors.destroy');
+        });
+});

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -45,5 +45,6 @@ Route::middleware('auth')->group(function () {
 
     Route::get('settings/tokens', [UserTokenController::class, 'index'])->name('settings.tokens.index');
     Route::post('settings/tokens', [UserTokenController::class, 'store'])->name('settings.tokens.store');
+    Route::patch('settings/tokens/{token}', [UserTokenController::class, 'update'])->name('settings.tokens.update');
     Route::delete('settings/tokens/{token}', [UserTokenController::class, 'destroy'])->name('settings.tokens.destroy');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -87,6 +87,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
             Route::get('tokens', [TokenController::class, 'index'])->name('tokens.index');
             Route::post('tokens', [TokenController::class, 'store'])->name('tokens.store');
+            Route::patch('tokens/{token}', [TokenController::class, 'update'])->name('tokens.update');
             Route::delete('tokens/{token}', [TokenController::class, 'destroy'])->name('tokens.destroy');
 
             Route::get('ssh-keys', [SshKeyController::class, 'index'])->name('ssh-keys');

--- a/tests/Feature/Api/V1/AuthTest.php
+++ b/tests/Feature/Api/V1/AuthTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Domains\Organization\Contracts\Enums\OrganizationRole;
+use App\Models\AccessToken;
+use App\Models\Organization;
+use App\Models\User;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->organization = Organization::factory()->create(['owner_uuid' => $this->user->uuid]);
+    joinOrganization($this->organization, $this->user, OrganizationRole::Owner);
+});
+
+it('authenticates a valid personal access token', function () {
+    $token = personalAccessToken($this->user);
+
+    $this->withToken($token)
+        ->getJson('/api/v1/user')
+        ->assertOk()
+        ->assertJson([
+            'uuid' => $this->user->uuid,
+            'email' => $this->user->email,
+        ]);
+});
+
+it('rejects a request without an Authorization header', function () {
+    $this->getJson('/api/v1/user')
+        ->assertUnauthorized()
+        ->assertJson(['message' => 'Unauthenticated.']);
+});
+
+it('rejects an unknown token', function () {
+    $this->withToken('does-not-exist')
+        ->getJson('/api/v1/user')
+        ->assertUnauthorized();
+});
+
+it('rejects an expired token', function () {
+    $plain = 'pat-expired-token';
+    AccessToken::factory()->forUser($this->user)->withPlainToken($plain)->expired()->create();
+
+    $this->withToken($plain)
+        ->getJson('/api/v1/user')
+        ->assertUnauthorized();
+});
+
+it('treats a null-scope (legacy) token as having full access', function () {
+    $token = personalAccessToken($this->user, scopes: null);
+
+    // read:repositories is required, but a legacy token implicitly carries every scope.
+    $this->withToken($token)
+        ->getJson("/api/v1/organizations/{$this->organization->slug}/repositories")
+        ->assertOk();
+});
+
+it('records last_used_at when a token authenticates', function () {
+    $token = personalAccessToken($this->user);
+
+    $this->withToken($token)->getJson('/api/v1/user')->assertOk();
+
+    expect(AccessToken::query()->where('token_hash', hash('sha256', $token))->first()->last_used_at)
+        ->not->toBeNull();
+});

--- a/tests/Feature/Api/V1/MemberApiTest.php
+++ b/tests/Feature/Api/V1/MemberApiTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Domains\Organization\Contracts\Enums\OrganizationRole;
+use App\Domains\Token\Contracts\Enums\TokenScope;
+use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Support\Facades\Notification;
+
+use function Pest\Laravel\assertDatabaseHas;
+
+beforeEach(function () {
+    $this->owner = User::factory()->create();
+    $this->organization = Organization::factory()->create(['owner_uuid' => $this->owner->uuid]);
+    joinOrganization($this->organization, $this->owner, OrganizationRole::Owner);
+});
+
+it('lists members with a pagination envelope', function () {
+    $token = personalAccessToken($this->owner, [TokenScope::ReadMembers]);
+
+    $this->withToken($token)
+        ->getJson("/api/v1/organizations/{$this->organization->slug}/members")
+        ->assertOk()
+        ->assertJsonStructure(['data', 'meta', 'links'])
+        ->assertJsonPath('data.0.email', $this->owner->email);
+});
+
+it('invites a member', function () {
+    Notification::fake();
+
+    $token = personalAccessToken($this->owner, [TokenScope::WriteMembers]);
+
+    $this->withToken($token)
+        ->postJson("/api/v1/organizations/{$this->organization->slug}/members", [
+            'email' => 'new@example.com',
+            'role' => 'member',
+        ])
+        ->assertCreated()
+        ->assertJsonPath('email', 'new@example.com');
+
+    assertDatabaseHas('organization_invitations', [
+        'organization_uuid' => $this->organization->uuid,
+        'email' => 'new@example.com',
+    ]);
+});
+
+it('forbids a plain member from inviting', function () {
+    $member = User::factory()->create();
+    joinOrganization($this->organization, $member, OrganizationRole::Member);
+
+    $token = personalAccessToken($member, [TokenScope::WriteMembers]);
+
+    $this->withToken($token)
+        ->postJson("/api/v1/organizations/{$this->organization->slug}/members", [
+            'email' => 'new@example.com',
+            'role' => 'member',
+        ])
+        ->assertForbidden();
+});

--- a/tests/Feature/Api/V1/OpenApiSpecTest.php
+++ b/tests/Feature/Api/V1/OpenApiSpecTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+
+it('generates a valid OpenAPI specification for the API', function () {
+    $path = storage_path('app/openapi-spec-test.json');
+
+    Artisan::call('scramble:export', ['--path' => $path]);
+
+    expect(file_exists($path))->toBeTrue();
+
+    $spec = json_decode((string) file_get_contents($path), true);
+    @unlink($path);
+
+    expect($spec['openapi'])->toStartWith('3.');
+    expect($spec['info']['title'])->toBe('Pricore API');
+    expect($spec['paths'])->not->toBeEmpty();
+
+    // The bearer security scheme is documented and applied globally.
+    expect(array_keys($spec['components']['securitySchemes']))->toContain('http');
+    expect($spec['components']['securitySchemes']['http']['scheme'])->toBe('bearer');
+    expect($spec['security'])->toBe([['http' => []]]);
+
+    // Core resources are present.
+    $paths = implode("\n", array_keys($spec['paths']));
+    expect($paths)->toContain('organizations');
+    expect($paths)->toContain('repositories');
+    expect($paths)->toContain('tokens');
+});

--- a/tests/Feature/Api/V1/OrganizationApiTest.php
+++ b/tests/Feature/Api/V1/OrganizationApiTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Domains\Organization\Contracts\Enums\OrganizationRole;
+use App\Domains\Token\Contracts\Enums\TokenScope;
+use App\Models\Organization;
+use App\Models\User;
+
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\assertDatabaseMissing;
+
+it('creates an organization with a personal access token', function () {
+    $user = User::factory()->create();
+    $token = personalAccessToken($user, [TokenScope::WriteOrganizations]);
+
+    $response = $this->withToken($token)
+        ->postJson('/api/v1/organizations', ['name' => 'Acme Inc'])
+        ->assertCreated()
+        ->assertJsonPath('name', 'Acme Inc');
+
+    assertDatabaseHas('organizations', [
+        'uuid' => $response->json('uuid'),
+        'owner_uuid' => $user->uuid,
+    ]);
+});
+
+it('does not allow organization-scoped tokens to create organizations', function () {
+    $owner = User::factory()->create();
+    $organization = Organization::factory()->create(['owner_uuid' => $owner->uuid]);
+    joinOrganization($organization, $owner, OrganizationRole::Owner);
+
+    $token = organizationAccessToken($organization, [TokenScope::WriteOrganizations]);
+
+    $this->withToken($token)
+        ->postJson('/api/v1/organizations', ['name' => 'Nope'])
+        ->assertForbidden();
+});
+
+it('shows an organization to a member', function () {
+    $user = User::factory()->create();
+    $organization = Organization::factory()->create(['owner_uuid' => $user->uuid]);
+    joinOrganization($organization, $user, OrganizationRole::Owner);
+
+    $token = personalAccessToken($user, [TokenScope::ReadOrganizations]);
+
+    $this->withToken($token)
+        ->getJson("/api/v1/organizations/{$organization->slug}")
+        ->assertOk()
+        ->assertJsonPath('slug', $organization->slug);
+});
+
+it('updates an organization name and slug as the owner', function () {
+    $user = User::factory()->create();
+    $organization = Organization::factory()->create(['owner_uuid' => $user->uuid]);
+    joinOrganization($organization, $user, OrganizationRole::Owner);
+
+    $token = personalAccessToken($user, [TokenScope::WriteOrganizations]);
+
+    $this->withToken($token)
+        ->patchJson("/api/v1/organizations/{$organization->slug}", [
+            'name' => 'Renamed Org',
+            'slug' => 'renamed-org',
+        ])
+        ->assertOk()
+        ->assertJsonPath('name', 'Renamed Org')
+        ->assertJsonPath('slug', 'renamed-org');
+});
+
+it('forbids a plain member from updating the organization', function () {
+    $owner = User::factory()->create();
+    $organization = Organization::factory()->create(['owner_uuid' => $owner->uuid]);
+    joinOrganization($organization, $owner, OrganizationRole::Owner);
+
+    $member = User::factory()->create();
+    joinOrganization($organization, $member, OrganizationRole::Member);
+
+    $token = personalAccessToken($member, [TokenScope::WriteOrganizations]);
+
+    $this->withToken($token)
+        ->patchJson("/api/v1/organizations/{$organization->slug}", ['name' => 'Hijacked'])
+        ->assertForbidden();
+});
+
+it('deletes an organization as the owner but forbids an admin', function () {
+    $owner = User::factory()->create();
+    $organization = Organization::factory()->create(['owner_uuid' => $owner->uuid]);
+    joinOrganization($organization, $owner, OrganizationRole::Owner);
+
+    $admin = User::factory()->create();
+    joinOrganization($organization, $admin, OrganizationRole::Admin);
+
+    // Admin has the scope but not ownership — policy denies.
+    $adminToken = personalAccessToken($admin, [TokenScope::DeleteOrganizations]);
+    $this->withToken($adminToken)
+        ->deleteJson("/api/v1/organizations/{$organization->slug}")
+        ->assertForbidden();
+
+    $ownerToken = personalAccessToken($owner, [TokenScope::DeleteOrganizations]);
+    $this->withToken($ownerToken)
+        ->deleteJson("/api/v1/organizations/{$organization->slug}")
+        ->assertNoContent();
+
+    assertDatabaseMissing('organizations', ['uuid' => $organization->uuid, 'deleted_at' => null]);
+});

--- a/tests/Feature/Api/V1/RepositoryApiTest.php
+++ b/tests/Feature/Api/V1/RepositoryApiTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Domains\Organization\Contracts\Enums\OrganizationRole;
+use App\Domains\Repository\Jobs\SyncRepositoryJob;
+use App\Domains\Token\Contracts\Enums\TokenScope;
+use App\Models\Organization;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Support\Facades\Queue;
+
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\assertDatabaseMissing;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->organization = Organization::factory()->create(['owner_uuid' => $this->user->uuid]);
+    joinOrganization($this->organization, $this->user, OrganizationRole::Owner);
+});
+
+it('lists repositories with a pagination envelope', function () {
+    Repository::factory()->count(3)->create(['organization_uuid' => $this->organization->uuid]);
+
+    $token = personalAccessToken($this->user, [TokenScope::ReadRepositories]);
+
+    $this->withToken($token)
+        ->getJson("/api/v1/organizations/{$this->organization->slug}/repositories?per_page=2")
+        ->assertOk()
+        ->assertJsonStructure(['data', 'meta', 'links'])
+        ->assertJsonCount(2, 'data')
+        ->assertJsonPath('meta.total', 3);
+});
+
+it('creates a repository and dispatches a sync', function () {
+    Queue::fake();
+
+    $token = personalAccessToken($this->user, [TokenScope::WriteRepositories]);
+
+    $this->withToken($token)
+        ->postJson("/api/v1/organizations/{$this->organization->slug}/repositories", [
+            'provider' => 'git',
+            'repo_identifier' => 'https://example.com/acme/widgets.git',
+        ])
+        ->assertCreated()
+        ->assertJsonPath('provider', 'git');
+
+    assertDatabaseHas('repositories', [
+        'organization_uuid' => $this->organization->uuid,
+        'repo_identifier' => 'https://example.com/acme/widgets.git',
+    ]);
+
+    Queue::assertPushed(SyncRepositoryJob::class);
+});
+
+it('deletes a repository with the delete scope', function () {
+    $repository = Repository::factory()->create(['organization_uuid' => $this->organization->uuid]);
+
+    $token = personalAccessToken($this->user, [TokenScope::DeleteRepositories]);
+
+    $this->withToken($token)
+        ->deleteJson("/api/v1/organizations/{$this->organization->slug}/repositories/{$repository->uuid}")
+        ->assertNoContent();
+
+    assertDatabaseMissing('repositories', ['uuid' => $repository->uuid]);
+});
+
+it('forbids a member from creating repositories', function () {
+    $member = User::factory()->create();
+    joinOrganization($this->organization, $member, OrganizationRole::Member);
+
+    $token = personalAccessToken($member, [TokenScope::WriteRepositories]);
+
+    $this->withToken($token)
+        ->postJson("/api/v1/organizations/{$this->organization->slug}/repositories", [
+            'provider' => 'git',
+            'repo_identifier' => 'https://example.com/acme/widgets.git',
+        ])
+        ->assertForbidden();
+});

--- a/tests/Feature/Api/V1/ScopeEnforcementTest.php
+++ b/tests/Feature/Api/V1/ScopeEnforcementTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Domains\Organization\Contracts\Enums\OrganizationRole;
+use App\Domains\Token\Contracts\Enums\TokenScope;
+use App\Models\Organization;
+use App\Models\Repository;
+use App\Models\User;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->organization = Organization::factory()->create(['owner_uuid' => $this->user->uuid]);
+    joinOrganization($this->organization, $this->user, OrganizationRole::Owner);
+});
+
+it('allows a request when the token carries the required scope', function () {
+    $token = personalAccessToken($this->user, [TokenScope::ReadRepositories]);
+
+    $this->withToken($token)
+        ->getJson("/api/v1/organizations/{$this->organization->slug}/repositories")
+        ->assertOk();
+});
+
+it('rejects a request when the token lacks the required scope', function () {
+    $token = personalAccessToken($this->user, [TokenScope::ReadPackages]);
+
+    $this->withToken($token)
+        ->getJson("/api/v1/organizations/{$this->organization->slug}/repositories")
+        ->assertForbidden()
+        ->assertJson(['required_scope' => 'read:repositories']);
+});
+
+it('requires a delete scope for destructive operations', function () {
+    // Has write but not delete — must not be able to delete.
+    $token = personalAccessToken($this->user, [TokenScope::WriteRepositories]);
+    $repository = Repository::factory()->create(['organization_uuid' => $this->organization->uuid]);
+
+    $this->withToken($token)
+        ->deleteJson("/api/v1/organizations/{$this->organization->slug}/repositories/{$repository->uuid}")
+        ->assertForbidden()
+        ->assertJson(['required_scope' => 'delete:repositories']);
+});

--- a/tests/Feature/Api/V1/TokenApiTest.php
+++ b/tests/Feature/Api/V1/TokenApiTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use App\Domains\Organization\Contracts\Enums\OrganizationRole;
+use App\Domains\Token\Contracts\Enums\TokenScope;
+use App\Models\AccessToken;
+use App\Models\Organization;
+use App\Models\User;
+
+use function Pest\Laravel\assertDatabaseHas;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->organization = Organization::factory()->create(['owner_uuid' => $this->user->uuid]);
+    joinOrganization($this->organization, $this->user, OrganizationRole::Owner);
+});
+
+it('creates an organization token with scopes and returns the plaintext once', function () {
+    // A full-access (legacy) personal token may grant any scope.
+    $token = personalAccessToken($this->user, scopes: null);
+
+    $response = $this->withToken($token)
+        ->postJson("/api/v1/organizations/{$this->organization->slug}/tokens", [
+            'name' => 'CI token',
+            'scopes' => ['composer', 'read:packages'],
+        ])
+        ->assertCreated()
+        ->assertJsonPath('name', 'CI token')
+        ->assertJsonPath('scopes', ['composer', 'read:packages']);
+
+    expect($response->json('plainToken'))->toBeString()->not->toBeEmpty();
+
+    assertDatabaseHas('access_tokens', [
+        'organization_uuid' => $this->organization->uuid,
+        'name' => 'CI token',
+    ]);
+});
+
+it('defaults new tokens to composer scope when none are given', function () {
+    $token = personalAccessToken($this->user, scopes: null);
+
+    $this->withToken($token)
+        ->postJson("/api/v1/organizations/{$this->organization->slug}/tokens", ['name' => 'Composer'])
+        ->assertCreated()
+        ->assertJsonPath('scopes', ['composer']);
+});
+
+it('prevents a scoped token from granting scopes it does not hold', function () {
+    // This token can write tokens, but does not itself hold delete:packages.
+    $token = personalAccessToken($this->user, [TokenScope::WriteTokens, TokenScope::ReadPackages]);
+
+    $this->withToken($token)
+        ->postJson("/api/v1/organizations/{$this->organization->slug}/tokens", [
+            'name' => 'Escalated',
+            'scopes' => ['delete:packages'],
+        ])
+        ->assertForbidden();
+});
+
+it('creates a personal access token via the user endpoint', function () {
+    $token = personalAccessToken($this->user, scopes: null);
+
+    $response = $this->withToken($token)
+        ->postJson('/api/v1/user/tokens', [
+            'name' => 'My laptop',
+            'scopes' => ['composer'],
+        ])
+        ->assertCreated()
+        ->assertJsonPath('name', 'My laptop');
+
+    expect($response->json('plainToken'))->toBeString()->not->toBeEmpty();
+
+    assertDatabaseHas('access_tokens', [
+        'user_uuid' => $this->user->uuid,
+        'name' => 'My laptop',
+    ]);
+});
+
+it('rejects invalid scopes', function () {
+    $token = personalAccessToken($this->user, scopes: null);
+
+    $this->withToken($token)
+        ->postJson("/api/v1/organizations/{$this->organization->slug}/tokens", [
+            'name' => 'Bad',
+            'scopes' => ['not-a-real-scope'],
+        ])
+        ->assertStatus(422);
+});
+
+it('updates an organization token name and scopes', function () {
+    $token = personalAccessToken($this->user, scopes: null);
+    $target = AccessToken::factory()
+        ->forOrganization($this->organization)
+        ->withScopes([TokenScope::Composer])
+        ->create();
+
+    $this->withToken($token)
+        ->patchJson("/api/v1/organizations/{$this->organization->slug}/tokens/{$target->uuid}", [
+            'name' => 'Renamed',
+            'scopes' => ['composer', 'write:repositories'],
+        ])
+        ->assertOk()
+        ->assertJsonPath('name', 'Renamed')
+        ->assertJsonPath('scopes', ['composer', 'write:repositories']);
+});
+
+it('keeps existing scopes on a name-only update', function () {
+    $token = personalAccessToken($this->user, scopes: null);
+    $target = AccessToken::factory()
+        ->forOrganization($this->organization)
+        ->withScopes([TokenScope::Composer, TokenScope::ReadPackages])
+        ->create();
+
+    $this->withToken($token)
+        ->patchJson("/api/v1/organizations/{$this->organization->slug}/tokens/{$target->uuid}", [
+            'name' => 'Just renamed',
+        ])
+        ->assertOk()
+        ->assertJsonPath('name', 'Just renamed')
+        ->assertJsonPath('scopes', ['composer', 'read:packages']);
+});
+
+it('prevents granting scopes the caller lacks on update', function () {
+    $token = personalAccessToken($this->user, [
+        TokenScope::WriteTokens,
+        TokenScope::ReadPackages,
+    ]);
+    $target = AccessToken::factory()
+        ->forOrganization($this->organization)
+        ->withScopes([TokenScope::Composer])
+        ->create();
+
+    $this->withToken($token)
+        ->patchJson("/api/v1/organizations/{$this->organization->slug}/tokens/{$target->uuid}", [
+            'name' => 'Escalate',
+            'scopes' => ['delete:packages'],
+        ])
+        ->assertForbidden();
+});

--- a/tests/Feature/Api/V1/TokenContextTest.php
+++ b/tests/Feature/Api/V1/TokenContextTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Domains\Organization\Contracts\Enums\OrganizationRole;
+use App\Domains\Token\Contracts\Enums\TokenScope;
+use App\Models\Organization;
+use App\Models\User;
+
+it('lets a personal access token act across all organizations the user belongs to', function () {
+    $user = User::factory()->create();
+    $orgA = Organization::factory()->create(['owner_uuid' => $user->uuid]);
+    $orgB = Organization::factory()->create(['owner_uuid' => $user->uuid]);
+    joinOrganization($orgA, $user, OrganizationRole::Owner);
+    joinOrganization($orgB, $user, OrganizationRole::Owner);
+
+    $token = personalAccessToken($user, [TokenScope::ReadRepositories]);
+
+    $this->withToken($token)->getJson("/api/v1/organizations/{$orgA->slug}/repositories")->assertOk();
+    $this->withToken($token)->getJson("/api/v1/organizations/{$orgB->slug}/repositories")->assertOk();
+});
+
+it('forbids a personal access token from organizations the user does not belong to', function () {
+    $user = User::factory()->create();
+    $orgA = Organization::factory()->create(['owner_uuid' => $user->uuid]);
+    joinOrganization($orgA, $user, OrganizationRole::Owner);
+
+    $otherOrg = Organization::factory()->create();
+
+    $token = personalAccessToken($user, [TokenScope::ReadRepositories]);
+
+    $this->withToken($token)
+        ->getJson("/api/v1/organizations/{$otherOrg->slug}/repositories")
+        ->assertForbidden();
+});
+
+it('isolates an organization-scoped token to its own organization', function () {
+    $owner = User::factory()->create();
+    $orgA = Organization::factory()->create(['owner_uuid' => $owner->uuid]);
+    $orgB = Organization::factory()->create(['owner_uuid' => $owner->uuid]);
+    joinOrganization($orgA, $owner, OrganizationRole::Owner);
+    joinOrganization($orgB, $owner, OrganizationRole::Owner);
+
+    $token = organizationAccessToken($orgA, [TokenScope::ReadRepositories]);
+
+    $this->withToken($token)->getJson("/api/v1/organizations/{$orgA->slug}/repositories")->assertOk();
+
+    // Even though the owner is a member of org B, the org-A token must not reach it.
+    $this->withToken($token)
+        ->getJson("/api/v1/organizations/{$orgB->slug}/repositories")
+        ->assertForbidden();
+});
+
+it('forbids organization-scoped tokens from personal endpoints', function () {
+    $owner = User::factory()->create();
+    $organization = Organization::factory()->create(['owner_uuid' => $owner->uuid]);
+    joinOrganization($organization, $owner, OrganizationRole::Owner);
+
+    $token = organizationAccessToken($organization);
+
+    $this->withToken($token)->getJson('/api/v1/user')->assertForbidden();
+});
+
+it('limits the organization listing of an organization token to its own organization', function () {
+    $owner = User::factory()->create();
+    $orgA = Organization::factory()->create(['owner_uuid' => $owner->uuid]);
+    $orgB = Organization::factory()->create(['owner_uuid' => $owner->uuid]);
+    joinOrganization($orgA, $owner, OrganizationRole::Owner);
+    joinOrganization($orgB, $owner, OrganizationRole::Owner);
+
+    $token = organizationAccessToken($orgA, [TokenScope::ReadOrganizations]);
+
+    $response = $this->withToken($token)->getJson('/api/v1/organizations')->assertOk();
+
+    expect($response->json('data'))->toHaveCount(1);
+    expect($response->json('data.0.uuid'))->toBe($orgA->uuid);
+});

--- a/tests/Feature/Composer/ComposerScopeTest.php
+++ b/tests/Feature/Composer/ComposerScopeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Domains\Token\Contracts\Enums\TokenScope;
+use App\Models\Organization;
+
+beforeEach(function () {
+    $this->organization = Organization::factory()->create(['slug' => 'acme']);
+});
+
+it('allows registry access for a token with the composer scope', function () {
+    $token = organizationAccessToken($this->organization, [TokenScope::Composer]);
+
+    $this->withToken($token)
+        ->getJson('/acme/packages.json')
+        ->assertOk();
+});
+
+it('allows registry access for a legacy null-scope token', function () {
+    $token = organizationAccessToken($this->organization, scopes: null);
+
+    $this->withToken($token)
+        ->getJson('/acme/packages.json')
+        ->assertOk();
+});
+
+it('forbids registry access for a token without the composer scope', function () {
+    $token = organizationAccessToken($this->organization, [TokenScope::ReadRepositories]);
+
+    $this->withToken($token)
+        ->getJson('/acme/packages.json')
+        ->assertForbidden();
+});

--- a/tests/Feature/Settings/UserTokenScopeTest.php
+++ b/tests/Feature/Settings/UserTokenScopeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Domains\Token\Contracts\Enums\TokenScope;
+use App\Models\AccessToken;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+
+it('creates a personal access token with the selected scopes', function () {
+    $user = User::factory()->create();
+
+    actingAs($user)->post(route('settings.tokens.store'), [
+        'name' => 'Scoped token',
+        'scopes' => ['composer', 'read:repositories'],
+    ]);
+
+    $token = AccessToken::query()->where('user_uuid', $user->uuid)->firstOrFail();
+
+    expect($token->scopes)->toEqual(['composer', 'read:repositories']);
+});
+
+it('defaults to the composer scope when none are selected', function () {
+    $user = User::factory()->create();
+
+    actingAs($user)->post(route('settings.tokens.store'), [
+        'name' => 'Default token',
+    ]);
+
+    $token = AccessToken::query()->where('user_uuid', $user->uuid)->firstOrFail();
+
+    expect($token->scopes)->toEqual(['composer']);
+});
+
+it('updates a personal token name and scopes', function () {
+    $user = User::factory()->create();
+    $token = AccessToken::factory()
+        ->forUser($user)
+        ->withScopes([TokenScope::Composer])
+        ->create();
+
+    actingAs($user)->patch(route('settings.tokens.update', $token->uuid), [
+        'name' => 'Renamed token',
+        'scopes' => ['composer', 'read:repositories'],
+    ]);
+
+    $token->refresh();
+
+    expect($token->name)->toBe('Renamed token');
+    expect($token->scopes)->toEqual(['composer', 'read:repositories']);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,12 @@
 <?php
 
+use App\Domains\Organization\Contracts\Enums\OrganizationRole;
+use App\Domains\Token\Contracts\Enums\TokenScope;
+use App\Models\AccessToken;
+use App\Models\Organization;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 
 /*
@@ -47,4 +53,53 @@ expect()->extend('toBeOne', function () {
 function something()
 {
     // ..
+}
+
+/**
+ * Attach a user to an organization with the given role.
+ */
+function joinOrganization(Organization $organization, User $user, OrganizationRole $role = OrganizationRole::Member): void
+{
+    $organization->members()->attach($user->uuid, [
+        'uuid' => (string) Str::uuid(),
+        'role' => $role->value,
+    ]);
+}
+
+/**
+ * Create a personal access token for a user and return its plaintext value.
+ *
+ * @param  array<int, TokenScope>|null  $scopes  Null grants full (legacy) access.
+ */
+function personalAccessToken(User $user, ?array $scopes = null): string
+{
+    $plain = 'pat-'.Str::random(48);
+
+    AccessToken::factory()
+        ->forUser($user)
+        ->withPlainToken($plain)
+        ->neverExpires()
+        ->state(['scopes' => $scopes === null ? null : array_map(fn (TokenScope $s) => $s->value, $scopes)])
+        ->create();
+
+    return $plain;
+}
+
+/**
+ * Create an organization-scoped access token and return its plaintext value.
+ *
+ * @param  array<int, TokenScope>|null  $scopes  Null grants full (legacy) access.
+ */
+function organizationAccessToken(Organization $organization, ?array $scopes = null): string
+{
+    $plain = 'org-'.Str::random(48);
+
+    AccessToken::factory()
+        ->forOrganization($organization)
+        ->withPlainToken($plain)
+        ->neverExpires()
+        ->state(['scopes' => $scopes === null ? null : array_map(fn (TokenScope $s) => $s->value, $scopes)])
+        ->create();
+
+    return $plain;
 }


### PR DESCRIPTION
Closes #106.

Adds a versioned `/api/v1` REST API for managing organizations, repositories, packages, members, invitations, mirrors, and access tokens, authenticated with a Bearer token (personal or organization-scoped).

- Introduces a `TokenScope` enum enforced per-route alongside the existing organization policies; tokens created before scopes existed keep full access, and the `composer` scope now gates registry access.
- Token settings let you choose scopes when creating a token and edit them afterwards, with an adaptive post-create dialog showing Composer and/or API usage.
- OpenAPI 3.1 spec auto-generated with Scramble (interactive docs at `/docs/api`, exported via `composer api:docs`).