### PR TITLE
fix(composer): preserve v prefix on package versions

### DIFF
--- a/app/Domains/Package/Contracts/Data/PackageVersionData.php
+++ b/app/Domains/Package/Contracts/Data/PackageVersionData.php
@@ -199,7 +199,7 @@ class PackageVersionData extends Data
 
     public function isStable(): bool
     {
-        return ! str_contains($this->version, 'dev') && preg_match('/^\d+\.\d+/', $this->version);
+        return ! str_contains($this->version, 'dev') && preg_match('/^v?\d+\.\d+/', $this->version);
     }
 
     public function isDev(): bool

--- a/app/Domains/Repository/Contracts/Data/ComposerMetadataData.php
+++ b/app/Domains/Repository/Contracts/Data/ComposerMetadataData.php
@@ -88,13 +88,10 @@ class ComposerMetadataData extends Data
      */
     public static function extractVersion(string $ref): string
     {
-        // Remove 'v' prefix if present (e.g., v1.0.0 -> 1.0.0)
-        if (str_starts_with($ref, 'v') && preg_match('/^v\d/', $ref)) {
-            return substr($ref, 1);
-        }
-
-        // Branch names need dev- prefix for Composer compatibility
-        if (! preg_match('/^\d+\.\d+/', $ref)) {
+        // Branch names need a dev- prefix for Composer compatibility. Version tags are
+        // kept verbatim (e.g. v1.0.0 stays v1.0.0) so the pretty version matches the
+        // original Git tag; Composer derives the normalized form separately.
+        if (! preg_match('/^v?\d+\.\d+/', $ref)) {
             return "dev-{$ref}";
         }
 

--- a/tests/Feature/Actions/FilterChangedRefsActionTest.php
+++ b/tests/Feature/Actions/FilterChangedRefsActionTest.php
@@ -66,7 +66,7 @@ it('filters out refs with unchanged commit SHAs', function () {
     PackageVersion::factory()
         ->forPackage($package)
         ->create([
-            'version' => '1.0.0',
+            'version' => 'v1.0.0',
             'source_reference' => 'abc123',
         ]);
 
@@ -100,7 +100,7 @@ it('keeps refs with changed commit SHAs', function () {
     PackageVersion::factory()
         ->forPackage($package)
         ->create([
-            'version' => '1.0.0',
+            'version' => 'v1.0.0',
             'source_reference' => 'old-sha',
         ]);
 
@@ -166,7 +166,7 @@ it('filters tags and branches independently', function () {
     PackageVersion::factory()
         ->forPackage($package)
         ->create([
-            'version' => '1.0.0',
+            'version' => 'v1.0.0',
             'source_reference' => 'tag-sha',
         ]);
 

--- a/tests/Feature/Actions/RemoveStaleVersionsActionTest.php
+++ b/tests/Feature/Actions/RemoveStaleVersionsActionTest.php
@@ -98,8 +98,8 @@ it('handles tags with v prefix correctly', function () {
     $repository = Repository::factory()->forOrganization($organization)->create();
     $package = Package::factory()->forOrganization($organization)->forRepository($repository)->create();
 
-    // Version stored without v prefix (extractVersion strips it)
-    PackageVersion::factory()->forPackage($package)->create(['version' => '1.0.0', 'normalized_version' => '1.0.0.0']);
+    // Version stored with the v prefix preserved, matching the original tag
+    PackageVersion::factory()->forPackage($package)->create(['version' => 'v1.0.0', 'normalized_version' => '1.0.0.0']);
 
     $refs = makeRefsCollection(
         tags: [
@@ -111,6 +111,27 @@ it('handles tags with v prefix correctly', function () {
     $removed = $action->handle($repository, $refs);
 
     expect($removed)->toBe(0);
+});
+
+it('removes legacy versions stored without the v prefix on re-sync', function () {
+    $organization = Organization::factory()->create();
+    $repository = Repository::factory()->forOrganization($organization)->create();
+    $package = Package::factory()->forOrganization($organization)->forRepository($repository)->create();
+
+    // Legacy row stored before the prefix was preserved
+    PackageVersion::factory()->forPackage($package)->create(['version' => '1.0.0', 'normalized_version' => '1.0.0.0']);
+
+    $refs = makeRefsCollection(
+        tags: [
+            ['name' => 'v1.0.0', 'commit' => 'abc123'],
+        ]
+    );
+
+    $action = app(RemoveStaleVersionsAction::class);
+    $removed = $action->handle($repository, $refs);
+
+    expect($removed)->toBe(1);
+    expect(PackageVersion::where('package_uuid', $package->uuid)->count())->toBe(0);
 });
 
 it('returns zero when repository has no packages', function () {

--- a/tests/Feature/Composer/ComposerApiTest.php
+++ b/tests/Feature/Composer/ComposerApiTest.php
@@ -77,6 +77,37 @@ it('returns package metadata in composer v2 format', function () {
         ->assertJsonPath('packages.acme/awesome-package.0.source.reference', 'abc123');
 });
 
+it('preserves the v prefix in the version field while normalizing separately', function () {
+    $package = Package::factory()
+        ->for($this->organization, 'organization')
+        ->create(['name' => 'acme/awesome-package']);
+
+    PackageVersion::factory()
+        ->for($package)
+        ->create([
+            'version' => 'v1.2.0',
+            'normalized_version' => '1.2.0.0',
+            'composer_json' => [
+                'name' => 'acme/awesome-package',
+                'type' => 'library',
+            ],
+            'source_url' => 'https://github.com/acme/awesome-package.git',
+            'source_reference' => 'abc123',
+        ]);
+
+    $response = authenticatedGet("/{$this->organization->slug}/p2/acme/awesome-package.json", $this->plainToken);
+
+    $response->assertOk();
+
+    $versions = $response->json('packages.acme/awesome-package');
+
+    // The pretty version keeps the original tag (so {$version} placeholders and
+    // installed pretty versions match), while the normalized form drives comparison.
+    expect($versions)->toHaveCount(1)
+        ->and($versions[0]['version'])->toBe('v1.2.0')
+        ->and($versions[0]['version_normalized'])->toBe('1.2.0.0');
+});
+
 it('returns multiple versions ordered by release date', function () {
     $package = Package::factory()
         ->for($this->organization, 'organization')

--- a/tests/Feature/Jobs/SyncRefJobTest.php
+++ b/tests/Feature/Jobs/SyncRefJobTest.php
@@ -56,7 +56,7 @@ it('syncs a single ref and creates a package version', function () {
     expect(PackageVersion::count())->toBe(1);
 
     $version = PackageVersion::first();
-    expect($version->version)->toBe('1.0.0');
+    expect($version->version)->toBe('v1.0.0');
     expect($version->source_reference)->toBe('abc123');
 });
 

--- a/tests/Unit/ComposerMetadataParserTest.php
+++ b/tests/Unit/ComposerMetadataParserTest.php
@@ -17,7 +17,7 @@ it('parses valid composer.json with tag version', function () {
 
     expect($result)->toBeInstanceOf(ComposerMetadataData::class)
         ->and($result->name)->toBe('vendor/package')
-        ->and($result->version)->toBe('1.0.0')
+        ->and($result->version)->toBe('v1.0.0')
         ->and($result->normalizedVersion)->toBe('1.0.0.0')
         ->and($result->type)->toBe('library')
         ->and($result->description)->toBe('Test package')
@@ -50,7 +50,7 @@ it('adds dev- prefix to non-semver branch names', function (string $ref, string 
     'simple branch' => ['develop', 'dev-develop'],
     'branch with slash' => ['feature/my-feature', 'dev-feature/my-feature'],
     'release branch' => ['carconnect-release', 'dev-carconnect-release'],
-    'tag version' => ['v1.0.0', '1.0.0'],
+    'tag version' => ['v1.0.0', 'v1.0.0'],
     'tag without v' => ['1.2.3', '1.2.3'],
 ]);
 


### PR DESCRIPTION
Version tags were stored with the `v` prefix stripped, so the Composer metadata `version` field no longer matched the original tag. The pretty version is now kept verbatim (`v1.2.0`), with the normalized form still driving comparison/ordering — matching Packagist behaviour.

- Fixes #156: `{$version}` placeholders in `extra.download-dist` URLs now resolve to the real tag (`v5.73.24`) instead of 404ing.
- Fixes #146: no more duplicate `1.2.0` / `v1.2.0` entries or phantom `composer outdated` updates.

Existing versions self-heal on the next repository sync; re-sync affected repos to update already-stored versions.