### PR TITLE
feat(composer): add per-organization anonymous pulling toggle

### DIFF
--- a/app/Domains/Organization/Contracts/Data/OrganizationData.php
+++ b/app/Domains/Organization/Contracts/Data/OrganizationData.php
@@ -20,6 +20,7 @@ class OrganizationData extends Data
         public ?bool $trialExpired = null,
         public bool $securityAuditsEnabled = true,
         public bool $securityNotificationsEnabled = true,
+        public bool $anonymousAccessEnabled = false,
     ) {}
 
     public static function fromModel(Organization $organization): self
@@ -32,6 +33,7 @@ class OrganizationData extends Data
             composerRepositoryUrl: url("/{$organization->slug}"),
             securityAuditsEnabled: $organization->security_audits_enabled,
             securityNotificationsEnabled: $organization->security_notifications_enabled,
+            anonymousAccessEnabled: $organization->anonymous_access_enabled,
         );
     }
 }

--- a/app/Domains/Security/Http/Controllers/SecuritySettingsController.php
+++ b/app/Domains/Security/Http/Controllers/SecuritySettingsController.php
@@ -31,6 +31,7 @@ class SecuritySettingsController extends Controller
         $validated = $request->validate([
             'security_audits_enabled' => ['required', 'boolean'],
             'security_notifications_enabled' => ['required', 'boolean'],
+            'anonymous_access_enabled' => ['required', 'boolean'],
         ]);
 
         $organization->update($validated);

--- a/app/Http/Middleware/ComposerTokenAuth.php
+++ b/app/Http/Middleware/ComposerTokenAuth.php
@@ -12,34 +12,39 @@ class ComposerTokenAuth
 {
     public function handle(Request $request, Closure $next): Response
     {
+        $organization = $this->resolveOrganization($request);
+
         $token = $this->extractToken($request);
+        $accessToken = $token ? $this->findAccessToken($token) : null;
 
-        if (! $token) {
-            return $this->unauthorized();
+        if ($accessToken && $accessToken->isValid() && $this->canAccessOrganization($accessToken, $organization)) {
+            $accessToken->markAsUsed();
+
+            $request->merge(['accessToken' => $accessToken]);
+
+            return $next($request);
         }
 
-        $accessToken = $this->findAccessToken($token);
+        // Fall back to anonymous access when the organization allows it
+        if ($organization?->anonymous_access_enabled) {
+            $request->merge(['accessToken' => null]);
 
-        if (! $accessToken || ! $accessToken->isValid()) {
-            return $this->unauthorized();
+            return $next($request);
         }
 
+        return $this->unauthorized();
+    }
+
+    protected function resolveOrganization(Request $request): ?Organization
+    {
         $organization = $request->route('organization');
 
         // Resolve the organization from slug if route model binding hasn't run yet
         if (is_string($organization)) {
-            $organization = Organization::where('slug', $organization)->first();
+            return Organization::where('slug', $organization)->first();
         }
 
-        if (! $this->canAccessOrganization($accessToken, $organization)) {
-            return $this->unauthorized();
-        }
-
-        $accessToken->markAsUsed();
-
-        $request->merge(['accessToken' => $accessToken]);
-
-        return $next($request);
+        return $organization instanceof Organization ? $organization : null;
     }
 
     protected function extractToken(Request $request): ?string

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $trial_ends_at
  * @property bool $security_audits_enabled
  * @property bool $security_notifications_enabled
+ * @property bool $anonymous_access_enabled
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property Carbon|null $deleted_at
@@ -73,6 +74,7 @@ class Organization extends Model
     protected $attributes = [
         'security_audits_enabled' => true,
         'security_notifications_enabled' => true,
+        'anonymous_access_enabled' => false,
     ];
 
     /**
@@ -84,6 +86,7 @@ class Organization extends Model
             'trial_ends_at' => 'datetime',
             'security_audits_enabled' => 'boolean',
             'security_notifications_enabled' => 'boolean',
+            'anonymous_access_enabled' => 'boolean',
         ];
     }
 

--- a/database/migrations/2026_06_20_000000_add_anonymous_access_to_organizations_table.php
+++ b/database/migrations/2026_06_20_000000_add_anonymous_access_to_organizations_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->boolean('anonymous_access_enabled')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->dropColumn('anonymous_access_enabled');
+        });
+    }
+};

--- a/resources/js/pages/organizations/settings/security.tsx
+++ b/resources/js/pages/organizations/settings/security.tsx
@@ -1,8 +1,10 @@
 import { update } from '@/actions/App/Domains/Security/Http/Controllers/SecuritySettingsController';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { withOrganizationSettingsLayout } from '@/layouts/organization-settings-layout';
 import { router } from '@inertiajs/react';
+import { TriangleAlert } from 'lucide-react';
 
 type OrganizationData =
     App.Domains.Organization.Contracts.Data.OrganizationData;
@@ -12,14 +14,16 @@ interface Props {
 }
 
 export default function Security({ organization }: Props) {
-    const handleToggle = (
-        field: string,
-        value: boolean,
-        otherFields: Record<string, boolean>,
-    ) => {
+    const updateSettings = (overrides: Record<string, boolean>) => {
         router.patch(
             update.url(organization.slug),
-            { [field]: value, ...otherFields },
+            {
+                security_audits_enabled: organization.securityAuditsEnabled,
+                security_notifications_enabled:
+                    organization.securityNotificationsEnabled,
+                anonymous_access_enabled: organization.anonymousAccessEnabled,
+                ...overrides,
+            },
             { preserveScroll: true },
         );
     };
@@ -29,8 +33,8 @@ export default function Security({ organization }: Props) {
             <div>
                 <h3 className="text-lg font-medium">Security Settings</h3>
                 <p className="text-muted-foreground">
-                    Configure security auditing and notifications for your
-                    organization
+                    Configure security auditing, notifications, and registry
+                    access for your organization
                 </p>
             </div>
 
@@ -47,10 +51,7 @@ export default function Security({ organization }: Props) {
                         id="security-audits"
                         checked={organization.securityAuditsEnabled}
                         onCheckedChange={(checked) =>
-                            handleToggle('security_audits_enabled', checked, {
-                                security_notifications_enabled:
-                                    organization.securityNotificationsEnabled,
-                            })
+                            updateSettings({ security_audits_enabled: checked })
                         }
                     />
                 </div>
@@ -70,17 +71,50 @@ export default function Security({ organization }: Props) {
                         checked={organization.securityNotificationsEnabled}
                         disabled={!organization.securityAuditsEnabled}
                         onCheckedChange={(checked) =>
-                            handleToggle(
-                                'security_notifications_enabled',
-                                checked,
-                                {
-                                    security_audits_enabled:
-                                        organization.securityAuditsEnabled,
-                                },
-                            )
+                            updateSettings({
+                                security_notifications_enabled: checked,
+                            })
                         }
                     />
                 </div>
+            </div>
+
+            <div className="space-y-4 rounded-lg border bg-card p-6">
+                <div className="flex items-center justify-between gap-4">
+                    <div className="space-y-0.5">
+                        <Label htmlFor="anonymous-access">
+                            Anonymous access
+                        </Label>
+                        <p className="text-sm text-muted-foreground">
+                            Allow pulling packages without a Composer
+                            authentication token
+                        </p>
+                    </div>
+                    <Switch
+                        id="anonymous-access"
+                        checked={organization.anonymousAccessEnabled}
+                        onCheckedChange={(checked) =>
+                            updateSettings({
+                                anonymous_access_enabled: checked,
+                            })
+                        }
+                    />
+                </div>
+
+                {organization.anonymousAccessEnabled && (
+                    <Alert variant="destructive">
+                        <TriangleAlert />
+                        <AlertTitle>
+                            All packages are publicly accessible
+                        </AlertTitle>
+                        <AlertDescription>
+                            Anyone who can reach this registry can pull every
+                            package in this organization without authentication.
+                            Only enable this if access is restricted by other
+                            means.
+                        </AlertDescription>
+                    </Alert>
+                )}
             </div>
         </div>
     );

--- a/resources/types/generated.d.ts
+++ b/resources/types/generated.d.ts
@@ -78,6 +78,7 @@ onTrial: boolean | null;
 trialExpired: boolean | null;
 securityAuditsEnabled: boolean;
 securityNotificationsEnabled: boolean;
+anonymousAccessEnabled: boolean;
 };
 export type OrganizationInvitationData = {
 uuid: string;

--- a/tests/Feature/Composer/ComposerApiTest.php
+++ b/tests/Feature/Composer/ComposerApiTest.php
@@ -418,6 +418,26 @@ it('returns ETag header on metadata responses', function () {
         ->assertHeader('ETag');
 });
 
+it('serves metadata without a token when anonymous access is enabled', function () {
+    $this->organization->update(['anonymous_access_enabled' => true]);
+
+    $package = Package::factory()
+        ->for($this->organization, 'organization')
+        ->create(['name' => 'acme/awesome-package']);
+
+    PackageVersion::factory()
+        ->for($package)
+        ->create(['version' => '1.0.0', 'normalized_version' => '1.0.0.0']);
+
+    test()->getJson("/{$this->organization->slug}/packages.json")
+        ->assertOk()
+        ->assertJsonPath('available-packages', ['acme/awesome-package']);
+
+    test()->getJson("/{$this->organization->slug}/p2/acme/awesome-package.json")
+        ->assertOk()
+        ->assertJsonPath('packages.acme/awesome-package.0.version', '1.0.0');
+});
+
 it('does not leak packages from other organizations', function () {
     $otherOrg = Organization::factory()->create(['slug' => 'other-org']);
 

--- a/tests/Feature/Middleware/ComposerTokenAuthTest.php
+++ b/tests/Feature/Middleware/ComposerTokenAuthTest.php
@@ -73,3 +73,29 @@ it('returns 401 for an expired token', function () {
         ['Authorization' => 'Basic '.$credentials]
     )->assertUnauthorized();
 });
+
+it('allows anonymous access when the organization enables it', function () {
+    $organization = Organization::factory()->create(['anonymous_access_enabled' => true]);
+
+    $this->getJson(
+        route('composer.packages.index', $organization),
+    )->assertSuccessful();
+});
+
+it('falls back to anonymous access for an invalid token when enabled', function () {
+    $organization = Organization::factory()->create(['anonymous_access_enabled' => true]);
+
+    $this->getJson(
+        route('composer.packages.index', $organization),
+        ['Authorization' => 'Bearer not-a-real-token']
+    )->assertSuccessful();
+});
+
+it('still serves a valid token when anonymous access is enabled', function () {
+    $this->organization->update(['anonymous_access_enabled' => true]);
+
+    $this->getJson(
+        route('composer.packages.index', $this->organization),
+        ['Authorization' => 'Bearer '.$this->plainToken]
+    )->assertSuccessful();
+});

--- a/tests/Feature/Security/SecuritySettingsTest.php
+++ b/tests/Feature/Security/SecuritySettingsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Domains\Organization\Contracts\Enums\OrganizationRole;
+use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Support\Str;
+
+beforeEach(function () {
+    $this->owner = User::factory()->create();
+    $this->organization = Organization::factory()->create(['owner_uuid' => $this->owner->uuid]);
+    $this->organization->members()->attach($this->owner->uuid, [
+        'uuid' => Str::uuid()->toString(),
+        'role' => OrganizationRole::Owner->value,
+    ]);
+});
+
+it('persists the anonymous access toggle', function () {
+    $this->actingAs($this->owner)
+        ->patch(route('organizations.settings.security.update', $this->organization), [
+            'security_audits_enabled' => true,
+            'security_notifications_enabled' => true,
+            'anonymous_access_enabled' => true,
+        ])
+        ->assertRedirect();
+
+    expect($this->organization->fresh()->anonymous_access_enabled)->toBeTrue();
+});
+
+it('requires the anonymous access field', function () {
+    $this->actingAs($this->owner)
+        ->patch(route('organizations.settings.security.update', $this->organization), [
+            'security_audits_enabled' => true,
+            'security_notifications_enabled' => true,
+        ])
+        ->assertSessionHasErrors('anonymous_access_enabled');
+});
+
+it('forbids a plain member from changing the anonymous access toggle', function () {
+    $member = User::factory()->create();
+    $this->organization->members()->attach($member->uuid, [
+        'uuid' => Str::uuid()->toString(),
+        'role' => OrganizationRole::Member->value,
+    ]);
+
+    $this->actingAs($member)
+        ->patch(route('organizations.settings.security.update', $this->organization), [
+            'security_audits_enabled' => true,
+            'security_notifications_enabled' => true,
+            'anonymous_access_enabled' => true,
+        ])
+        ->assertForbidden();
+
+    expect($this->organization->fresh()->anonymous_access_enabled)->toBeFalse();
+});


### PR DESCRIPTION
Closes #136

Adds a per-organization **Anonymous access** toggle (Security settings, off by default). When enabled, the org's Composer registry can be pulled without an authentication token — for operators who secure access by other means or self-host without needing data privacy.

- The gate lives entirely in `ComposerTokenAuth`: a valid token still works as before; with the toggle on, unauthenticated (or non-matching) requests fall through to anonymous access. With it off, behaviour is unchanged (401).