### PR TITLE
fix(composer): serve dists for legacy version URLs without v prefix

### DIFF
--- a/app/Http/Controllers/Composer/DistController.php
+++ b/app/Http/Controllers/Composer/DistController.php
@@ -21,15 +21,17 @@ class DistController extends Controller
     ): Response {
         $packageName = "{$vendor}/{$package}";
 
-        $packageVersion = PackageVersion::query()
+        $packageVersions = PackageVersion::query()
             ->whereHas('package', function ($query) use ($organization, $packageName) {
                 $query->where('organization_uuid', $organization->uuid)
                     ->where('name', $packageName);
             })
-            ->where('version', $version)
+            ->matchingVersion($version)
             ->where('source_reference', $reference)
             ->whereNotNull('dist_path')
-            ->first();
+            ->get();
+
+        $packageVersion = $packageVersions->firstWhere('version', $version) ?? $packageVersions->first();
 
         if (! $packageVersion || ! $packageVersion->dist_path) {
             return response()->json(['error' => 'Not found'], 404);

--- a/app/Models/PackageVersion.php
+++ b/app/Models/PackageVersion.php
@@ -109,6 +109,24 @@ class PackageVersion extends Model
     }
 
     /**
+     * Lock files created before versions kept their v prefix reference dist
+     * URLs without it, so match the version with and without the prefix.
+     *
+     * @param  Builder<PackageVersion>  $query
+     * @return Builder<PackageVersion>
+     */
+    public function scopeMatchingVersion(Builder $query, string $version): Builder
+    {
+        $candidates = match (true) {
+            preg_match('/^\d/', $version) === 1 => [$version, "v{$version}"],
+            preg_match('/^v\d/', $version) === 1 => [$version, substr($version, 1)],
+            default => [$version],
+        };
+
+        return $query->whereIn('version', $candidates);
+    }
+
+    /**
      * @param  Builder<PackageVersion>  $query
      * @return Builder<PackageVersion>
      */

--- a/tests/Feature/Composer/DistDownloadTest.php
+++ b/tests/Feature/Composer/DistDownloadTest.php
@@ -130,6 +130,75 @@ it('downloads a dist archive for a branch version with slashes', function () {
     $response->assertOk();
 });
 
+it('downloads a dist archive when requesting a v-prefixed version without the prefix', function () {
+    $package = Package::factory()
+        ->for($this->organization, 'organization')
+        ->create(['name' => 'acme/test-package']);
+
+    $distPath = 'acme/acme/test-package/v1.2.0_abc123def456.zip';
+    Storage::disk('local')->put($distPath, 'fake-zip-content');
+
+    PackageVersion::factory()
+        ->for($package)
+        ->create([
+            'version' => 'v1.2.0',
+            'source_reference' => 'abc123def456',
+            'dist_url' => url('/acme/dists/acme/test-package/v1.2.0/abc123def456.zip'),
+            'dist_path' => $distPath,
+            'dist_shasum' => sha1('fake-zip-content'),
+        ]);
+
+    $response = distGet('/acme/dists/acme/test-package/1.2.0/abc123def456.zip', $this->plainToken);
+
+    $response->assertOk();
+});
+
+it('downloads a dist archive when requesting an unprefixed version with a v prefix', function () {
+    $package = Package::factory()
+        ->for($this->organization, 'organization')
+        ->create(['name' => 'acme/test-package']);
+
+    $distPath = 'acme/acme/test-package/1.2.0_abc123def456.zip';
+    Storage::disk('local')->put($distPath, 'fake-zip-content');
+
+    PackageVersion::factory()
+        ->for($package)
+        ->create([
+            'version' => '1.2.0',
+            'source_reference' => 'abc123def456',
+            'dist_url' => url('/acme/dists/acme/test-package/1.2.0/abc123def456.zip'),
+            'dist_path' => $distPath,
+            'dist_shasum' => sha1('fake-zip-content'),
+        ]);
+
+    $response = distGet('/acme/dists/acme/test-package/v1.2.0/abc123def456.zip', $this->plainToken);
+
+    $response->assertOk();
+});
+
+it('returns 404 for a legacy version request with a non-matching reference', function () {
+    $package = Package::factory()
+        ->for($this->organization, 'organization')
+        ->create(['name' => 'acme/test-package']);
+
+    $distPath = 'acme/acme/test-package/v1.2.0_abc123def456.zip';
+    Storage::disk('local')->put($distPath, 'fake-zip-content');
+
+    PackageVersion::factory()
+        ->for($package)
+        ->create([
+            'version' => 'v1.2.0',
+            'source_reference' => 'abc123def456',
+            'dist_url' => url('/acme/dists/acme/test-package/v1.2.0/abc123def456.zip'),
+            'dist_path' => $distPath,
+            'dist_shasum' => sha1('fake-zip-content'),
+        ]);
+
+    $response = distGet('/acme/dists/acme/test-package/1.2.0/0123456789ab.zip', $this->plainToken);
+
+    $response->assertNotFound();
+});
+
 it('requires authentication for dist download', function () {
     $response = test()->getJson('/acme/dists/acme/test-package/1.0.0/abc123.zip');
 


### PR DESCRIPTION
- Lock files generated before #159 reference dist URLs without the `v` prefix, which now 404 after a re-sync recreates versions with the prefix. Dist downloads now match the requested version with and without the prefix via a `matchingVersion` scope; the full commit SHA in the URL keeps the lookup unambiguous.
- Branch versions (`dev-*`) are matched verbatim as before.