### PR TITLE
fix(security): make the example env match the invite-only default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,9 @@ APP_MAINTENANCE_DRIVER=file
 
 BCRYPT_ROUNDS=12
 
-SIGN_UP_ENABLED=true
+# Public registration. Leave disabled to keep the instance invite-only; create the
+# first user with `php artisan pricore:install`.
+SIGN_UP_ENABLED=false
 
 LOG_CHANNEL=stack
 LOG_STACK=single

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,14 @@ cd pricore
 
 # Install dependencies and set up the project
 composer setup
+
+# Create your first user and organization
+php artisan pricore:install
 ```
+
+Registration is invite-only by default, so `pricore:install` is how you get an account
+to sign in with. Set `SIGN_UP_ENABLED=true` in `.env` if you would rather register
+through the UI.
 
 ### Running the Development Server
 

--- a/docs/self-hosting/index.md
+++ b/docs/self-hosting/index.md
@@ -50,6 +50,14 @@ For custom setups or environments without Docker:
 4. Configure environment
 5. Set up a web server (nginx, Apache, or FrankenPHP)
 6. Configure process manager (systemd, supervisor)
+7. Create the first user and organization:
+
+```bash
+php artisan pricore:install
+```
+
+Registration is invite-only by default, so this command is how you get your first
+account. To allow anyone to register instead, see [`SIGN_UP_ENABLED`](/getting-started/configuration#registration).
 
 ## Scaling
 


### PR DESCRIPTION
`.env.example` shipped `SIGN_UP_ENABLED=true` while `config/fortify.php` and the docs both document the default as `false`. Since `composer setup` copies the example file, manual installs silently opted into open registration. Docker installs were unaffected — the entrypoint never copies the example.

Documents `pricore:install` in the manual deployment and contributing setup steps, which previously relied on self-registration to create the first account.