### PR TITLE
fix(security): restrict generic git repository URLs to network transports

### DIFF
--- a/app/Domains/Repository/Actions/CreateGitCloneAction.php
+++ b/app/Domains/Repository/Actions/CreateGitCloneAction.php
@@ -4,6 +4,7 @@ namespace App\Domains\Repository\Actions;
 
 use App\Domains\Repository\Contracts\Enums\GitProvider;
 use App\Domains\Repository\Exceptions\GitProviderException;
+use App\Domains\Repository\Rules\ValidRepositoryIdentifier;
 use App\Models\Repository;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Str;
@@ -14,6 +15,12 @@ class CreateGitCloneAction
     {
         if ($repository->provider !== GitProvider::Git) {
             return null;
+        }
+
+        // Guarded at the point of use, not only at request validation: git runs the
+        // command in an `ext::` address and reads a leading dash as an option.
+        if (! ValidRepositoryIdentifier::passes($repository->repo_identifier, GitProvider::Git)) {
+            throw new GitProviderException('Refusing to clone an unsupported repository URL.');
         }
 
         $clonePath = storage_path("app/git-clones/{$repository->uuid}");
@@ -37,7 +44,7 @@ class CreateGitCloneAction
 
         try {
             $result = Process::env($env)
-                ->run(['git', 'clone', '--bare', $repository->repo_identifier, $clonePath]);
+                ->run(['git', 'clone', '--bare', '--', $repository->repo_identifier, $clonePath]);
 
             if ($result->failed()) {
                 throw new GitProviderException('Failed to clone repository: '.$result->errorOutput());

--- a/app/Domains/Repository/Http/Requests/BulkStoreRepositoryRequest.php
+++ b/app/Domains/Repository/Http/Requests/BulkStoreRepositoryRequest.php
@@ -3,6 +3,7 @@
 namespace App\Domains\Repository\Http\Requests;
 
 use App\Domains\Repository\Contracts\Enums\GitProvider;
+use App\Domains\Repository\Rules\ValidRepositoryIdentifier;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -17,7 +18,12 @@ class BulkStoreRepositoryRequest extends FormRequest
         return [
             'provider' => ['required', 'string', Rule::enum(GitProvider::class)],
             'repositories' => ['required', 'array', 'min:1', 'max:50'],
-            'repositories.*.repo_identifier' => ['required', 'string', 'max:500'],
+            'repositories.*.repo_identifier' => [
+                'required',
+                'string',
+                'max:500',
+                new ValidRepositoryIdentifier(GitProvider::tryFrom((string) $this->input('provider'))),
+            ],
         ];
     }
 }

--- a/app/Domains/Repository/Http/Requests/StoreRepositoryRequest.php
+++ b/app/Domains/Repository/Http/Requests/StoreRepositoryRequest.php
@@ -3,6 +3,7 @@
 namespace App\Domains\Repository\Http\Requests;
 
 use App\Domains\Repository\Contracts\Enums\GitProvider;
+use App\Domains\Repository\Rules\ValidRepositoryIdentifier;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -17,7 +18,12 @@ class StoreRepositoryRequest extends FormRequest
         return [
             'name' => ['nullable', 'string', 'max:255'],
             'provider' => ['required', 'string', Rule::enum(GitProvider::class)],
-            'repo_identifier' => ['required', 'string', 'max:500'],
+            'repo_identifier' => [
+                'required',
+                'string',
+                'max:500',
+                new ValidRepositoryIdentifier(GitProvider::tryFrom((string) $this->input('provider'))),
+            ],
             'default_branch' => ['nullable', 'string', 'max:255'],
             'ssh_key_uuid' => ['nullable', 'uuid', Rule::exists('organization_ssh_keys', 'uuid')],
         ];

--- a/app/Domains/Repository/Rules/ValidRepositoryIdentifier.php
+++ b/app/Domains/Repository/Rules/ValidRepositoryIdentifier.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Domains\Repository\Rules;
+
+use App\Domains\Repository\Contracts\Enums\GitProvider;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Str;
+
+/**
+ * Validates the shape of a repository identifier before it can reach the git CLI.
+ *
+ * API-backed providers take an "owner/repo" slug. The generic Git provider takes a
+ * URL that is handed to `git clone` / `git ls-remote` verbatim, so it must be
+ * restricted to network transports: git happily executes commands for
+ * `ext::<command>`, treats a leading dash as an option, and reads the local
+ * filesystem for `file://` and bare paths.
+ */
+class ValidRepositoryIdentifier implements ValidationRule
+{
+    /**
+     * Transports git may be pointed at. Notably excludes `file` (local disclosure)
+     * and the helper transports reachable through `<transport>::<address>`.
+     */
+    public const ALLOWED_SCHEMES = ['https', 'http', 'ssh', 'git'];
+
+    public function __construct(private readonly ?GitProvider $provider) {}
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value) || trim($value) === '') {
+            $fail('The :attribute must be a non-empty string.');
+
+            return;
+        }
+
+        if ($this->provider === null) {
+            $fail('The :attribute cannot be validated without a known provider.');
+
+            return;
+        }
+
+        if (static::passes($value, $this->provider)) {
+            return;
+        }
+
+        $fail($this->provider === GitProvider::Git
+            ? 'The :attribute must be an https, http, ssh or git URL.'
+            : 'The :attribute must be in "owner/repository" format.');
+    }
+
+    public static function passes(string $value, GitProvider $provider): bool
+    {
+        return $provider === GitProvider::Git
+            ? static::isSafeGitUrl($value)
+            : static::isSafeSlug($value, $provider);
+    }
+
+    /**
+     * A URL git may be pointed at without handing control of the host to the caller.
+     */
+    public static function isSafeGitUrl(string $value): bool
+    {
+        $value = trim($value);
+
+        if ($value === '' || Str::startsWith($value, '-')) {
+            return false;
+        }
+
+        // `<transport>::<address>` selects a remote helper — `ext::` runs arbitrary commands.
+        if (str_contains($value, '::')) {
+            return false;
+        }
+
+        if (preg_match('#^([A-Za-z][A-Za-z0-9+.-]*)://#', $value, $matches) === 1) {
+            if (! in_array(strtolower($matches[1]), static::ALLOWED_SCHEMES, true)) {
+                return false;
+            }
+
+            $host = parse_url($value, PHP_URL_HOST);
+
+            return is_string($host) && $host !== '';
+        }
+
+        // scp-style shorthand, e.g. git@github.com:owner/repo.git
+        return preg_match('#^[A-Za-z0-9._-]+@[A-Za-z0-9.-]+:(?!/)\S+$#', $value) === 1;
+    }
+
+    /**
+     * An "owner/repo" slug for the API-backed providers. GitLab allows subgroup nesting.
+     */
+    public static function isSafeSlug(string $value, GitProvider $provider): bool
+    {
+        $value = trim($value);
+
+        $pattern = $provider === GitProvider::GitLab
+            ? '#^[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)+$#'
+            : '#^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$#';
+
+        if (preg_match($pattern, $value) !== 1) {
+            return false;
+        }
+
+        // Reject traversal segments that the character class would otherwise allow.
+        foreach (explode('/', $value) as $segment) {
+            if ($segment === '.' || $segment === '..') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/app/Domains/Repository/Services/GitProviders/CachedGitProvider.php
+++ b/app/Domains/Repository/Services/GitProviders/CachedGitProvider.php
@@ -25,6 +25,10 @@ class CachedGitProvider implements GitProviderInterface
 
     public function getFileContent(string $ref, string $path): ?string
     {
+        if (! $this->isUsableRef($ref)) {
+            return null;
+        }
+
         $result = Process::path($this->clonePath)
             ->env(['GIT_TERMINAL_PROMPT' => '0'])
             ->run(['git', 'show', "{$ref}:{$path}"]);
@@ -63,10 +67,23 @@ class CachedGitProvider implements GitProviderInterface
 
     public function downloadArchive(string $ref, string $outputPath): bool
     {
+        if (! $this->isUsableRef($ref)) {
+            return false;
+        }
+
         $result = Process::path($this->clonePath)
             ->env(['GIT_TERMINAL_PROMPT' => '0'])
             ->run(['git', 'archive', '--format=zip', "--output={$outputPath}", $ref]);
 
         return $result->successful() && file_exists($outputPath);
+    }
+
+    /**
+     * Neither `git show` nor `git archive` takes a `--` separator before a revision,
+     * so a ref from a remote that begins with a dash would be read as an option.
+     */
+    protected function isUsableRef(string $ref): bool
+    {
+        return $ref !== '' && ! str_starts_with($ref, '-');
     }
 }

--- a/app/Domains/Repository/Services/GitProviders/GenericGitProvider.php
+++ b/app/Domains/Repository/Services/GitProviders/GenericGitProvider.php
@@ -2,7 +2,9 @@
 
 namespace App\Domains\Repository\Services\GitProviders;
 
+use App\Domains\Repository\Contracts\Enums\GitProvider;
 use App\Domains\Repository\Exceptions\GitProviderException;
+use App\Domains\Repository\Rules\ValidRepositoryIdentifier;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
@@ -22,7 +24,7 @@ class GenericGitProvider extends AbstractGitProvider
      */
     public function getTags(): array
     {
-        $output = $this->runGitCommand(['ls-remote', '--tags', '--refs', $this->getAuthenticatedUrl()]);
+        $output = $this->runGitCommand(['ls-remote', '--tags', '--refs', '--', $this->getAuthenticatedUrl()]);
 
         return $this->parseLsRemoteOutput($output, 'refs/tags/');
     }
@@ -32,7 +34,7 @@ class GenericGitProvider extends AbstractGitProvider
      */
     public function getBranches(): array
     {
-        $output = $this->runGitCommand(['ls-remote', '--heads', $this->getAuthenticatedUrl()]);
+        $output = $this->runGitCommand(['ls-remote', '--heads', '--', $this->getAuthenticatedUrl()]);
 
         return $this->parseLsRemoteOutput($output, 'refs/heads/');
     }
@@ -52,6 +54,7 @@ class GenericGitProvider extends AbstractGitProvider
                 'clone',
                 '--depth', '1',
                 '--branch', $ref,
+                '--',
                 $this->getAuthenticatedUrl(),
                 $tempDir,
             ]);
@@ -77,7 +80,7 @@ class GenericGitProvider extends AbstractGitProvider
     public function validateCredentials(): bool
     {
         try {
-            $this->runGitCommand(['ls-remote', $this->getAuthenticatedUrl(), 'HEAD']);
+            $this->runGitCommand(['ls-remote', '--', $this->getAuthenticatedUrl(), 'HEAD']);
 
             return true;
         } catch (\Exception $e) {
@@ -109,13 +112,20 @@ class GenericGitProvider extends AbstractGitProvider
     {
         $url = $this->repositoryIdentifier;
 
+        // Never hand git an address it could read as a transport helper, a local path,
+        // or an option. Request validation covers new repositories; this covers rows
+        // stored before that validation existed, or written by any other path.
+        if (! ValidRepositoryIdentifier::passes($url, GitProvider::Git)) {
+            throw new GitProviderException('Refusing to use an unsupported repository URL.');
+        }
+
         // SSH URLs are passed through unchanged — auth is handled via GIT_SSH_COMMAND
         if ($this->hasCredential('ssh_key') || ! Str::startsWith($url, ['http://', 'https://'])) {
             return $url;
         }
 
-        // Basic check if URL is http(s) and we have credentials
-        if (Str::startsWith($url, ['http://', 'https://']) && $this->hasCredential('username') && $this->hasCredential('password')) {
+        // The URL is guaranteed http(s) here, so only credentials remain to check
+        if ($this->hasCredential('username') && $this->hasCredential('password')) {
             $username = urlencode($this->getCredential('username'));
             $password = urlencode($this->getCredential('password'));
 

--- a/tests/Feature/Security/RepositoryIdentifierValidationTest.php
+++ b/tests/Feature/Security/RepositoryIdentifierValidationTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use App\Domains\Organization\Contracts\Enums\OrganizationRole;
+use App\Domains\Repository\Contracts\Enums\GitProvider;
+use App\Domains\Repository\Rules\ValidRepositoryIdentifier;
+use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Support\Str;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\assertDatabaseCount;
+
+uses()->group('security', 'repositories');
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->organization = Organization::factory()->create(['owner_uuid' => $this->user->uuid]);
+    $this->organization->members()->attach($this->user->uuid, [
+        'uuid' => Str::uuid()->toString(),
+        'role' => OrganizationRole::Owner->value,
+    ]);
+});
+
+/**
+ * git executes the command in an `ext::` address, reads the local filesystem for
+ * `file://` and bare paths, and parses a leading dash as an option — so none of
+ * these may ever reach the CLI.
+ */
+it('rejects git identifiers that would give git control of the host', function (string $identifier) {
+    actingAs($this->user)
+        ->post(route('organizations.repositories.store', $this->organization->slug), [
+            'provider' => GitProvider::Git->value,
+            'repo_identifier' => $identifier,
+        ])
+        ->assertSessionHasErrors('repo_identifier');
+
+    assertDatabaseCount('repositories', 0);
+})->with([
+    'ext transport' => 'ext::sh -c "id > /tmp/pwned"',
+    'ext transport uppercase' => 'EXT::sh -c id',
+    'other remote helper' => 'fd::7',
+    'file scheme' => 'file:///etc/passwd',
+    'absolute path' => '/etc/passwd',
+    'relative path' => '../../etc/passwd',
+    'option injection' => '--upload-pack=id',
+    'short option' => '-u',
+    'empty' => ' ',
+]);
+
+it('accepts ordinary git remote URLs', function (string $identifier) {
+    expect(ValidRepositoryIdentifier::passes($identifier, GitProvider::Git))->toBeTrue();
+})->with([
+    'https' => 'https://git.example.com/acme/widgets.git',
+    'http' => 'http://git.example.com/acme/widgets.git',
+    'ssh scheme' => 'ssh://git@git.example.com:2222/acme/widgets.git',
+    'git scheme' => 'git://git.example.com/acme/widgets.git',
+    'scp shorthand' => 'git@git.example.com:acme/widgets.git',
+]);
+
+it('rejects slugs that are not owner/repository', function (string $identifier) {
+    actingAs($this->user)
+        ->post(route('organizations.repositories.store', $this->organization->slug), [
+            'provider' => GitProvider::GitHub->value,
+            'repo_identifier' => $identifier,
+        ])
+        ->assertSessionHasErrors('repo_identifier');
+
+    assertDatabaseCount('repositories', 0);
+})->with([
+    'url instead of slug' => 'https://github.com/acme/widgets',
+    'traversal' => 'acme/../../../etc',
+    'single segment' => 'acme',
+    'trailing segment' => 'acme/widgets/extra',
+]);
+
+it('allows gitlab subgroup nesting but not github', function () {
+    expect(ValidRepositoryIdentifier::passes('group/subgroup/widgets', GitProvider::GitLab))->toBeTrue()
+        ->and(ValidRepositoryIdentifier::passes('group/subgroup/widgets', GitProvider::GitHub))->toBeFalse();
+});
+
+it('rejects unsafe identifiers on the bulk import endpoint', function () {
+    actingAs($this->user)
+        ->post(route('organizations.repositories.bulk-store', $this->organization->slug), [
+            'provider' => GitProvider::Git->value,
+            'repositories' => [
+                ['repo_identifier' => 'https://git.example.com/acme/widgets.git'],
+                ['repo_identifier' => 'ext::sh -c id'],
+            ],
+        ])
+        ->assertSessionHasErrors('repositories.1.repo_identifier');
+
+    assertDatabaseCount('repositories', 0);
+});


### PR DESCRIPTION
Repository identifiers for the generic Git provider were validated only as `string|max:500` before being passed to `git`. Git accepts addresses that are not network URLs, so a repository could be pointed at things it should never reach.

Adds a provider-aware `ValidRepositoryIdentifier` rule: API-backed providers take an `owner/repo` slug, and the generic Git provider is limited to `https`, `http`, `ssh` and `git` URLs or scp-style `user@host:path`.

The same check runs again where `git` is actually invoked, so identifiers already stored — or written by any path other than the form — are refused too. Command arguments now use a `--` separator so an address can never be read as an option.

Split out of #172 so it can be reviewed and released on its own.