### PR TITLE
fix(composer): record dist archives per commit so locked versions install

### DIFF
--- a/app/Domains/Composer/Actions/ResolveDistArchiveAction.php
+++ b/app/Domains/Composer/Actions/ResolveDistArchiveAction.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Domains\Composer\Actions;
+
+use App\Domains\Repository\Contracts\Data\DistArchiveData;
+use App\Models\Organization;
+use App\Models\Package;
+use App\Models\PackageVersion;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Facades\Storage;
+
+class ResolveDistArchiveAction
+{
+    /**
+     * Resolve the stored archive for a requested version and commit reference.
+     *
+     * A branch keeps a single version row that every sync moves to the new head,
+     * so the requested commit is often one the row has already moved past. Every
+     * archive is recorded against its own commit, which keeps those lock files
+     * installable.
+     */
+    public function handle(
+        Organization $organization,
+        string $packageName,
+        string $version,
+        string $reference,
+    ): ?string {
+        $package = Package::query()
+            ->where('organization_uuid', $organization->uuid)
+            ->where('name', $packageName)
+            ->first();
+
+        if (! $package) {
+            return null;
+        }
+
+        $packageVersions = PackageVersion::query()
+            ->where('package_uuid', $package->uuid)
+            ->matchingVersion($version)
+            ->with(['archives' => fn (Relation $query) => $query->where('source_reference', $reference)])
+            ->get();
+
+        if ($packageVersions->isEmpty()) {
+            return null;
+        }
+
+        // Rows matching the request exactly win over the v-prefix variants
+        // scopeMatchingVersion also returns.
+        $candidates = $this->orderByExactVersion($packageVersions, $version);
+
+        $disk = Storage::disk(config('pricore.dist.disk'));
+
+        foreach ($candidates as $candidate) {
+            $archive = $candidate->archives->first();
+
+            if ($archive && $disk->exists($archive->path)) {
+                return $archive->path;
+            }
+        }
+
+        // Archives written before the dist_archives backfill
+        // (2026_08_29_000002_backfill_dist_archives) that their branch had
+        // already moved past have no row, because only the version's current
+        // dist_path could be backfilled. Their storage path is deterministic,
+        // so recover them by name. Removable once no supported upgrade path
+        // predates that migration.
+        foreach ($candidates as $candidate) {
+            $legacyPath = DistArchiveData::pathFor(
+                organizationSlug: $organization->slug,
+                packageName: $packageName,
+                version: $candidate->version,
+                reference: $reference,
+            );
+
+            if ($disk->exists($legacyPath)) {
+                return $legacyPath;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  Collection<int, PackageVersion>  $packageVersions
+     * @return Collection<int, PackageVersion>
+     */
+    protected function orderByExactVersion(Collection $packageVersions, string $version): Collection
+    {
+        return $packageVersions
+            ->sortByDesc(fn (PackageVersion $packageVersion): bool => $packageVersion->version === $version)
+            ->values();
+    }
+}

--- a/app/Domains/Mirror/Actions/DownloadMirrorDistAction.php
+++ b/app/Domains/Mirror/Actions/DownloadMirrorDistAction.php
@@ -64,8 +64,12 @@ class DownloadMirrorDistAction
                 return null;
             }
 
-            $refShort = substr($packageVersion->source_reference ?? '', 0, 12);
-            $storagePath = "{$organizationSlug}/{$package->name}/{$packageVersion->version}_{$refShort}.zip";
+            $storagePath = DistArchiveData::pathFor(
+                organizationSlug: $organizationSlug,
+                packageName: $package->name,
+                version: $packageVersion->version,
+                reference: $packageVersion->source_reference ?? '',
+            );
 
             $disk = Storage::disk(config('pricore.dist.disk'));
             $stream = fopen($tempPath, 'r');

--- a/app/Domains/Mirror/Actions/RemoveStaleMirrorVersionsAction.php
+++ b/app/Domains/Mirror/Actions/RemoveStaleMirrorVersionsAction.php
@@ -31,12 +31,16 @@ class RemoveStaleMirrorVersionsAction
                 continue;
             }
 
-            $deleted = (int) PackageVersion::query()
+            // One at a time so the deleting hook removes each version's archive
+            // files; a bulk delete fires no events and strands them.
+            PackageVersion::query()
                 ->where('package_uuid', $package->uuid)
                 ->whereNotIn('version', $upstreamVersions)
-                ->delete();
-
-            $totalDeleted += $deleted;
+                ->lazyById(100, 'uuid')
+                ->each(function (PackageVersion $version) use (&$totalDeleted) {
+                    $version->delete();
+                    $totalDeleted++;
+                });
         }
 
         if ($totalDeleted > 0) {

--- a/app/Domains/Mirror/Actions/SyncMirrorPackageVersionAction.php
+++ b/app/Domains/Mirror/Actions/SyncMirrorPackageVersionAction.php
@@ -3,13 +3,19 @@
 namespace App\Domains\Mirror\Actions;
 
 use App\Domains\Mirror\Contracts\Enums\SyncVersionResult;
+use App\Domains\Repository\Actions\DetachDistArchivesTask;
 use App\Models\Package;
 use App\Models\PackageVersion;
 use Composer\Semver\VersionParser;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 class SyncMirrorPackageVersionAction
 {
+    public function __construct(
+        protected DetachDistArchivesTask $detachDistArchivesTask,
+    ) {}
+
     /**
      * @param  array<string, mixed>  $composerJson
      */
@@ -31,13 +37,19 @@ class SyncMirrorPackageVersionAction
                 return SyncVersionResult::Skipped;
             }
 
-            $existingVersion->update([
-                'normalized_version' => $normalizedVersion,
-                'composer_json' => $composerJson,
-                'source_url' => $composerJson['source']['url'] ?? null,
-                'source_reference' => $sourceReference,
-                'released_at' => isset($composerJson['time']) ? $composerJson['time'] : null,
-            ]);
+            DB::transaction(function () use ($existingVersion, $normalizedVersion, $composerJson, $sourceReference) {
+                // Release the archive built for the old reference before moving,
+                // so the stale dist is never advertised under the new one.
+                $this->detachDistArchivesTask->handle($existingVersion);
+
+                $existingVersion->update([
+                    'normalized_version' => $normalizedVersion,
+                    'composer_json' => $composerJson,
+                    'source_url' => $composerJson['source']['url'] ?? null,
+                    'source_reference' => $sourceReference,
+                    'released_at' => isset($composerJson['time']) ? $composerJson['time'] : null,
+                ]);
+            });
 
             return SyncVersionResult::Updated;
         }

--- a/app/Domains/Mirror/Jobs/SyncMirrorVersionJob.php
+++ b/app/Domains/Mirror/Jobs/SyncMirrorVersionJob.php
@@ -8,6 +8,7 @@ use App\Domains\Mirror\Actions\SyncMirrorPackageVersionAction;
 use App\Domains\Mirror\Contracts\Enums\SyncVersionResult;
 use App\Domains\Mirror\Exceptions\MirrorDistDownloadException;
 use App\Domains\Mirror\Services\RegistryClient\RegistryClientFactory;
+use App\Domains\Repository\Actions\RecordDistArchiveAction;
 use App\Models\Mirror;
 use App\Models\Package;
 use App\Models\PackageVersion;
@@ -39,6 +40,7 @@ class SyncMirrorVersionJob implements ShouldQueue
         FindOrCreateMirrorPackageAction $findOrCreateMirrorPackageAction,
         SyncMirrorPackageVersionAction $syncMirrorPackageVersionAction,
         DownloadMirrorDistAction $downloadMirrorDistAction,
+        RecordDistArchiveAction $recordDistArchiveAction,
     ): void {
         if ($this->batch()?->cancelled()) {
             return;
@@ -65,12 +67,13 @@ class SyncMirrorVersionJob implements ShouldQueue
         $this->incrementCounter($result);
 
         if ($this->mirror->mirror_dist && config('pricore.dist.enabled')) {
-            $this->mirrorDist($downloadMirrorDistAction, $package);
+            $this->mirrorDist($downloadMirrorDistAction, $recordDistArchiveAction, $package);
         }
     }
 
     protected function mirrorDist(
         DownloadMirrorDistAction $downloadMirrorDistAction,
+        RecordDistArchiveAction $recordDistArchiveAction,
         Package $package,
     ): void {
         $packageVersion = PackageVersion::query()
@@ -78,7 +81,18 @@ class SyncMirrorVersionJob implements ShouldQueue
             ->where('version', $this->version)
             ->first();
 
-        if (! $packageVersion || $packageVersion->dist_path) {
+        if (! $packageVersion || ! $packageVersion->source_reference) {
+            return;
+        }
+
+        // Ask whether we hold an archive for the reference we are serving now,
+        // not merely whether we hold one at all: a dev version whose upstream
+        // reference moved needs re-downloading.
+        $alreadyMirrored = $packageVersion->archives()
+            ->where('source_reference', $packageVersion->source_reference)
+            ->exists();
+
+        if ($alreadyMirrored) {
             return;
         }
 
@@ -96,14 +110,7 @@ class SyncMirrorVersionJob implements ShouldQueue
                 return;
             }
 
-            $distUrl = url("/{$organizationSlug}/dists/{$package->name}/{$packageVersion->version}/{$packageVersion->source_reference}.zip");
-
-            $packageVersion->update([
-                'dist_url' => $distUrl,
-                'dist_path' => $dist->path,
-                'dist_shasum' => $dist->shasum,
-                'dist_size' => $dist->size,
-            ]);
+            $recordDistArchiveAction->handle($packageVersion, $dist, $organizationSlug);
         } catch (MirrorDistDownloadException $e) {
             $this->incrementCounter(SyncVersionResult::DistFailed);
 

--- a/app/Domains/Package/Http/Controllers/PackageController.php
+++ b/app/Domains/Package/Http/Controllers/PackageController.php
@@ -13,6 +13,7 @@ use App\Domains\Package\Contracts\Data\PackageVersionDetailData;
 use App\Http\Controllers\Controller;
 use App\Models\Organization;
 use App\Models\Package;
+use App\Models\PackageVersion;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -62,8 +63,12 @@ class PackageController extends Controller
             properties: ['name' => $package->name],
         );
 
-        // Delete versions through Eloquent to trigger dist file cleanup
-        $package->versions()->each(fn ($version) => $version->delete());
+        // Deleted through Eloquent to trigger dist file cleanup, and keyed by id
+        // rather than offset: each() pages with OFFSET, so deleting as it goes
+        // would skip versions and leave their archives behind.
+        $package->versions()
+            ->lazyById(100, 'uuid')
+            ->each(fn (PackageVersion $version) => $version->delete());
 
         $package->delete();
 

--- a/app/Domains/Repository/Actions/CleanupDistArchivesAction.php
+++ b/app/Domains/Repository/Actions/CleanupDistArchivesAction.php
@@ -2,8 +2,11 @@
 
 namespace App\Domains\Repository\Actions;
 
+use App\Models\DistArchive;
 use App\Models\Package;
 use App\Models\PackageVersion;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Facades\Storage;
 
 class CleanupDistArchivesAction
 {
@@ -12,9 +15,66 @@ class CleanupDistArchivesAction
     ) {}
 
     /**
-     * @return array{packages: int, archives_removed: int}
+     * @return array{packages: int, archives_removed: int, detached_marked: int, detached_removed: int}
      */
     public function handle(): array
+    {
+        $detachedMarked = $this->repairDetachedArchives();
+
+        [$packagesProcessed, $archivesRemoved] = $this->applyReleaseRetention();
+
+        $detachedRemoved = $this->applyDetachedRetention();
+
+        return [
+            'packages' => $packagesProcessed,
+            'archives_removed' => $archivesRemoved,
+            'detached_marked' => $detachedMarked,
+            'detached_removed' => $detachedRemoved,
+        ];
+    }
+
+    /**
+     * Repair archives that stopped being current without going through
+     * DetachDistArchivesTask, then clear pointers left describing them.
+     *
+     * The dist_* columns are a write-through cache; this is what keeps them
+     * honest when a sync dies between moving the reference and recording the
+     * new archive.
+     *
+     * @return int Number of archives newly marked detached
+     */
+    protected function repairDetachedArchives(): int
+    {
+        $marked = DistArchive::query()
+            ->whereNull('detached_at')
+            ->whereNotExists(fn (QueryBuilder $query) => $query
+                ->from('package_versions')
+                ->whereColumn('package_versions.uuid', 'dist_archives.package_version_uuid')
+                ->whereColumn('package_versions.source_reference', 'dist_archives.source_reference'))
+            ->update(['detached_at' => now()]);
+
+        PackageVersion::query()
+            ->whereNotNull('dist_path')
+            ->whereNotExists(fn (QueryBuilder $query) => $query
+                ->from('dist_archives')
+                ->whereColumn('dist_archives.package_version_uuid', 'package_versions.uuid')
+                ->whereNull('dist_archives.detached_at'))
+            ->update([
+                'dist_url' => null,
+                'dist_path' => null,
+                'dist_shasum' => null,
+                'dist_size' => null,
+            ]);
+
+        return $marked;
+    }
+
+    /**
+     * Per-package retention of stable release archives.
+     *
+     * @return array{0: int, 1: int} Packages processed, archives removed
+     */
+    protected function applyReleaseRetention(): array
     {
         $packagesProcessed = 0;
         $archivesRemoved = 0;
@@ -44,9 +104,48 @@ class CleanupDistArchivesAction
                 }
             });
 
-        return [
-            'packages' => $packagesProcessed,
-            'archives_removed' => $archivesRemoved,
-        ];
+        return [$packagesProcessed, $archivesRemoved];
+    }
+
+    /**
+     * Prune archives whose branch moved on, once they are older than the
+     * configured window. Unset means keep them indefinitely.
+     *
+     * @return int Number of detached archives removed
+     */
+    protected function applyDetachedRetention(): int
+    {
+        $keepDays = $this->keepDetachedDays();
+
+        if ($keepDays === 0) {
+            return 0;
+        }
+
+        $disk = Storage::disk(config('pricore.dist.disk'));
+        $cutoff = now()->subDays($keepDays);
+        $removed = 0;
+
+        DistArchive::query()
+            ->detached()
+            ->where('detached_at', '<', $cutoff)
+            ->lazyById(500, 'uuid')
+            ->each(function (DistArchive $archive) use ($disk, &$removed) {
+                $disk->delete($archive->path);
+                $archive->delete();
+                $removed++;
+            });
+
+        return $removed;
+    }
+
+    protected function keepDetachedDays(): int
+    {
+        $keepDays = config('pricore.dist.keep_detached_days');
+
+        if (! is_numeric($keepDays) || (int) $keepDays <= 0) {
+            return 0;
+        }
+
+        return (int) $keepDays;
     }
 }

--- a/app/Domains/Repository/Actions/CreateDistArchiveAction.php
+++ b/app/Domains/Repository/Actions/CreateDistArchiveAction.php
@@ -33,8 +33,12 @@ class CreateDistArchiveAction
                 return null;
             }
 
-            $refShort = substr($version->source_reference, 0, 12);
-            $storagePath = "{$organizationSlug}/{$version->package->name}/{$version->version}_{$refShort}.zip";
+            $storagePath = DistArchiveData::pathFor(
+                organizationSlug: $organizationSlug,
+                packageName: $version->package->name,
+                version: $version->version,
+                reference: $version->source_reference,
+            );
 
             $disk = Storage::disk(config('pricore.dist.disk'));
             $stream = fopen($tempPath, 'r');

--- a/app/Domains/Repository/Actions/DetachDistArchivesTask.php
+++ b/app/Domains/Repository/Actions/DetachDistArchivesTask.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Domains\Repository\Actions;
+
+use App\Models\DistArchive;
+use App\Models\PackageVersion;
+
+class DetachDistArchivesTask
+{
+    /**
+     * Release a version from its current archive.
+     *
+     * Must run in the same transaction as any change to source_reference:
+     * leaving the dist_* columns describing the previous commit would advertise
+     * the old archive, and its matching shasum, under the new reference.
+     */
+    public function handle(PackageVersion $version): void
+    {
+        DistArchive::query()
+            ->where('package_version_uuid', $version->uuid)
+            ->whereNull('detached_at')
+            ->update(['detached_at' => now()]);
+
+        $version->update([
+            'dist_url' => null,
+            'dist_path' => null,
+            'dist_shasum' => null,
+            'dist_size' => null,
+        ]);
+    }
+}

--- a/app/Domains/Repository/Actions/PurgeDistArchiveFilesTask.php
+++ b/app/Domains/Repository/Actions/PurgeDistArchiveFilesTask.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Domains\Repository\Actions;
+
+use App\Models\DistArchive;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Storage;
+
+class PurgeDistArchiveFilesTask
+{
+    /**
+     * Delete archive files for a set of packages before their rows disappear.
+     *
+     * Deleting a repository cascades packages, versions and archive rows at the
+     * database level, which fires no model events. Without this the files are
+     * stranded on disk with nothing left pointing at them.
+     *
+     * @param  Collection<int, string>  $packageUuids
+     * @return int Number of files deleted
+     */
+    public function handle(Collection $packageUuids): int
+    {
+        if ($packageUuids->isEmpty()) {
+            return 0;
+        }
+
+        $disk = Storage::disk(config('pricore.dist.disk'));
+        $deleted = 0;
+
+        DistArchive::query()
+            ->whereIn('package_uuid', $packageUuids->all())
+            ->lazyById(500, 'uuid')
+            ->each(function (DistArchive $archive) use ($disk, &$deleted) {
+                $disk->delete($archive->path);
+                $deleted++;
+            });
+
+        return $deleted;
+    }
+}

--- a/app/Domains/Repository/Actions/RecordDistArchiveAction.php
+++ b/app/Domains/Repository/Actions/RecordDistArchiveAction.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Domains\Repository\Actions;
+
+use App\Domains\Repository\Contracts\Data\DistArchiveData;
+use App\Models\DistArchive;
+use App\Models\PackageVersion;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+class RecordDistArchiveAction
+{
+    /**
+     * Record an archive and point the version at it.
+     *
+     * The single writer of dist_archives rows and of the package_versions
+     * dist_* columns, which are a write-through cache of the current archive.
+     * Archives the version has moved past are marked detached but their files
+     * are deliberately kept, so lock files pinning those commits still install.
+     */
+    public function handle(
+        PackageVersion $version,
+        DistArchiveData $archive,
+        string $organizationSlug,
+    ): ?DistArchive {
+        $reference = $version->source_reference;
+
+        if (! $reference) {
+            return null;
+        }
+
+        return DB::transaction(function () use ($version, $archive, $organizationSlug, $reference): DistArchive {
+            $existingPath = DistArchive::query()
+                ->where('package_version_uuid', $version->uuid)
+                ->where('source_reference', $reference)
+                ->value('path');
+
+            $distArchive = DistArchive::query()->updateOrCreate(
+                [
+                    'package_version_uuid' => $version->uuid,
+                    'source_reference' => $reference,
+                ],
+                [
+                    'package_uuid' => $version->package_uuid,
+                    'path' => $archive->path,
+                    'shasum' => $archive->shasum,
+                    'size' => $archive->size,
+                    'detached_at' => null,
+                ],
+            );
+
+            // Only reachable when the organization slug or package name changed
+            // under an existing archive; without this the old file is stranded.
+            if ($existingPath && $existingPath !== $archive->path) {
+                Storage::disk(config('pricore.dist.disk'))->delete($existingPath);
+            }
+
+            DistArchive::query()
+                ->where('package_version_uuid', $version->uuid)
+                ->whereKeyNot($distArchive->uuid)
+                ->whereNull('detached_at')
+                ->update(['detached_at' => now()]);
+
+            $version->update([
+                'dist_url' => DistArchiveData::urlFor(
+                    organizationSlug: $organizationSlug,
+                    packageName: $version->package->name,
+                    version: $version->version,
+                    reference: $reference,
+                ),
+                'dist_path' => $archive->path,
+                'dist_shasum' => $archive->shasum,
+                'dist_size' => $archive->size,
+            ]);
+
+            return $distArchive;
+        });
+    }
+}

--- a/app/Domains/Repository/Actions/RemoveDistArchiveTask.php
+++ b/app/Domains/Repository/Actions/RemoveDistArchiveTask.php
@@ -7,10 +7,21 @@ use Illuminate\Support\Facades\Storage;
 
 class RemoveDistArchiveTask
 {
+    /**
+     * Drop every archive a version owns, files and rows alike, and clear the
+     * pointer columns.
+     */
     public function handle(PackageVersion $version): void
     {
+        $disk = Storage::disk(config('pricore.dist.disk'));
+
+        foreach ($version->archives()->get() as $archive) {
+            $disk->delete($archive->path);
+            $archive->delete();
+        }
+
         if ($version->dist_path) {
-            Storage::disk(config('pricore.dist.disk'))->delete($version->dist_path);
+            $disk->delete($version->dist_path);
         }
 
         $version->update([

--- a/app/Domains/Repository/Actions/RemoveStaleVersionsAction.php
+++ b/app/Domains/Repository/Actions/RemoveStaleVersionsAction.php
@@ -33,10 +33,18 @@ class RemoveStaleVersionsAction
             return 0;
         }
 
-        $deleted = PackageVersion::query()
+        // Deleted one model at a time so the deleting hook removes each version's
+        // archive files; a bulk delete fires no events and strands them.
+        $deleted = 0;
+
+        PackageVersion::query()
             ->whereIn('package_uuid', $packageUuids)
             ->whereNotIn('version', $currentVersions)
-            ->delete();
+            ->lazyById(100, 'uuid')
+            ->each(function (PackageVersion $version) use (&$deleted) {
+                $version->delete();
+                $deleted++;
+            });
 
         if ($deleted > 0) {
             Log::info('Removed stale package versions', [

--- a/app/Domains/Repository/Actions/SyncRefAction.php
+++ b/app/Domains/Repository/Actions/SyncRefAction.php
@@ -17,6 +17,8 @@ class SyncRefAction
         protected FindOrCreatePackageAction $findOrCreatePackage,
         protected CreateDistArchiveAction $createDistArchive,
         protected FetchReadmeAction $fetchReadmeAction,
+        protected RecordDistArchiveAction $recordDistArchiveAction,
+        protected DetachDistArchivesTask $detachDistArchivesTask,
     ) {}
 
     /**
@@ -73,6 +75,11 @@ class SyncRefAction
                 ->first();
 
             if ($version) {
+                // The archive still describes the old commit, so release it
+                // before the reference moves. Same transaction: a stale pointer
+                // would serve the previous archive under the new reference.
+                $this->detachDistArchivesTask->handle($version);
+
                 // Version exists but commit SHA changed - update it
                 $version->update([
                     'normalized_version' => $metadata->normalizedVersion,
@@ -123,14 +130,7 @@ class SyncRefAction
                 return;
             }
 
-            $distUrl = url("/{$organizationSlug}/dists/{$package->name}/{$version->version}/{$version->source_reference}.zip");
-
-            $version->update([
-                'dist_url' => $distUrl,
-                'dist_path' => $dist->path,
-                'dist_shasum' => $dist->shasum,
-                'dist_size' => $dist->size,
-            ]);
+            $this->recordDistArchiveAction->handle($version, $dist, $organizationSlug);
         } catch (\Throwable $e) {
             Log::warning('Failed to create dist archive', [
                 'package' => $package->name,

--- a/app/Domains/Repository/Commands/CleanupDistArchivesCommand.php
+++ b/app/Domains/Repository/Commands/CleanupDistArchivesCommand.php
@@ -19,6 +19,16 @@ class CleanupDistArchivesCommand extends Command
             "Cleaned up {$result['archives_removed']} archives across {$result['packages']} packages."
         );
 
+        if ($result['detached_marked'] > 0) {
+            $this->components->info(
+                "Marked {$result['detached_marked']} archives detached from a moved reference."
+            );
+        }
+
+        $this->components->info(
+            "Removed {$result['detached_removed']} detached archives past the retention window."
+        );
+
         return self::SUCCESS;
     }
 }

--- a/app/Domains/Repository/Contracts/Data/DistArchiveData.php
+++ b/app/Domains/Repository/Contracts/Data/DistArchiveData.php
@@ -11,4 +11,33 @@ class DistArchiveData extends Data
         public string $shasum,
         public int $size,
     ) {}
+
+    /**
+     * Storage path for an archive. Deterministic on purpose: downloads resolve
+     * archives for a commit the version row no longer points at by rebuilding
+     * this path, so every writer must derive it here.
+     */
+    public static function pathFor(
+        string $organizationSlug,
+        string $packageName,
+        string $version,
+        string $reference,
+    ): string {
+        $referenceShort = substr($reference, 0, 12);
+
+        return "{$organizationSlug}/{$packageName}/{$version}_{$referenceShort}.zip";
+    }
+
+    /**
+     * Public download URL for an archive, as advertised in Composer metadata.
+     * Unlike the storage path this carries the full reference.
+     */
+    public static function urlFor(
+        string $organizationSlug,
+        string $packageName,
+        string $version,
+        string $reference,
+    ): string {
+        return url("/{$organizationSlug}/dists/{$packageName}/{$version}/{$reference}.zip");
+    }
 }

--- a/app/Domains/Repository/Http/Controllers/RepositoryController.php
+++ b/app/Domains/Repository/Http/Controllers/RepositoryController.php
@@ -10,6 +10,7 @@ use App\Domains\Package\Contracts\Data\PackageData;
 use App\Domains\Repository\Actions\BulkCreateRepositoriesAction;
 use App\Domains\Repository\Actions\DeleteWebhookAction;
 use App\Domains\Repository\Actions\ExtractRepositoryNameAction;
+use App\Domains\Repository\Actions\PurgeDistArchiveFilesTask;
 use App\Domains\Repository\Actions\RegisterWebhookAction;
 use App\Domains\Repository\Contracts\Data\RepositoryData;
 use App\Domains\Repository\Contracts\Data\SyncLogData;
@@ -37,6 +38,7 @@ class RepositoryController extends Controller
         protected RegisterWebhookAction $registerWebhookAction,
         protected DeleteWebhookAction $deleteWebhookAction,
         protected RecordActivityTask $recordActivity,
+        protected PurgeDistArchiveFilesTask $purgeDistArchiveFilesTask,
     ) {}
 
     public function index(Organization $organization): Response
@@ -216,6 +218,10 @@ class RepositoryController extends Controller
         );
 
         $this->deleteWebhookAction->handle($repository);
+
+        // Packages, versions and archive rows all cascade at the database level,
+        // which fires no model events. Clear the files while the rows still exist.
+        $this->purgeDistArchiveFilesTask->handle($repository->packages()->pluck('uuid'));
 
         $repository->delete();
 

--- a/app/Http/Controllers/Composer/DistController.php
+++ b/app/Http/Controllers/Composer/DistController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers\Composer;
 
+use App\Domains\Composer\Actions\ResolveDistArchiveAction;
 use App\Http\Controllers\Controller;
 use App\Models\Organization;
-use App\Models\PackageVersion;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\Response;
@@ -18,33 +18,21 @@ class DistController extends Controller
         string $package,
         string $version,
         string $reference,
+        ResolveDistArchiveAction $resolveDistArchiveAction,
     ): Response {
-        $packageName = "{$vendor}/{$package}";
+        $distPath = $resolveDistArchiveAction->handle(
+            organization: $organization,
+            packageName: "{$vendor}/{$package}",
+            version: $version,
+            reference: $reference,
+        );
 
-        $packageVersions = PackageVersion::query()
-            ->whereHas('package', function ($query) use ($organization, $packageName) {
-                $query->where('organization_uuid', $organization->uuid)
-                    ->where('name', $packageName);
-            })
-            ->matchingVersion($version)
-            ->where('source_reference', $reference)
-            ->whereNotNull('dist_path')
-            ->get();
-
-        $packageVersion = $packageVersions->firstWhere('version', $version) ?? $packageVersions->first();
-
-        if (! $packageVersion || ! $packageVersion->dist_path) {
+        if (! $distPath) {
             return response()->json(['error' => 'Not found'], 404);
         }
-
-        $distPath = $packageVersion->dist_path;
 
         /** @var FilesystemAdapter $disk */
         $disk = Storage::disk(config('pricore.dist.disk'));
-
-        if (! $disk->exists($distPath)) {
-            return response()->json(['error' => 'Not found'], 404);
-        }
 
         /** @var string $diskName */
         $diskName = config('pricore.dist.disk');

--- a/app/Models/DistArchive.php
+++ b/app/Models/DistArchive.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Concerns\HasUuids;
+use Database\Factories\DistArchiveFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * A dist archive file that was written to the dist disk.
+ *
+ * Branches keep a single package_versions row that every sync moves to the new
+ * head, so one version produces many archives over time. Each stays addressable
+ * here by its own commit, which is what keeps lock files installable.
+ *
+ * @property string $uuid
+ * @property string $package_uuid
+ * @property string $package_version_uuid
+ * @property string $source_reference
+ * @property string $path
+ * @property string|null $shasum
+ * @property int|null $size
+ * @property Carbon|null $detached_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Package $package
+ * @property-read PackageVersion $packageVersion
+ *
+ * @method static Builder<static>|DistArchive current()
+ * @method static Builder<static>|DistArchive detached()
+ * @method static DistArchiveFactory factory($count = null, $state = [])
+ * @method static Builder<static>|DistArchive newModelQuery()
+ * @method static Builder<static>|DistArchive newQuery()
+ * @method static Builder<static>|DistArchive query()
+ *
+ * @mixin \Eloquent
+ */
+class DistArchive extends Model
+{
+    /** @use HasFactory<DistArchiveFactory> */
+    use HasFactory, HasUuids;
+
+    protected $guarded = ['uuid'];
+
+    protected function casts(): array
+    {
+        return [
+            'detached_at' => 'datetime',
+            'size' => 'integer',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Package, $this>
+     */
+    public function package(): BelongsTo
+    {
+        return $this->belongsTo(Package::class, 'package_uuid', 'uuid');
+    }
+
+    /**
+     * @return BelongsTo<PackageVersion, $this>
+     */
+    public function packageVersion(): BelongsTo
+    {
+        return $this->belongsTo(PackageVersion::class, 'package_version_uuid', 'uuid');
+    }
+
+    /**
+     * The archive the version currently resolves to.
+     *
+     * @param  Builder<DistArchive>  $query
+     * @return Builder<DistArchive>
+     */
+    public function scopeCurrent(Builder $query): Builder
+    {
+        return $query->whereNull('detached_at');
+    }
+
+    /**
+     * Archives their version has moved past. Kept on disk so lock files pinning
+     * the older commit stay installable.
+     *
+     * @param  Builder<DistArchive>  $query
+     * @return Builder<DistArchive>
+     */
+    public function scopeDetached(Builder $query): Builder
+    {
+        return $query->whereNotNull('detached_at');
+    }
+}

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -30,6 +30,7 @@ use Illuminate\Support\Carbon;
  * @property-read Repository|null $repository
  * @property-read Mirror|null $mirror
  * @property-read Collection<int, PackageVersion> $versions
+ * @property-read Collection<int, DistArchive> $distArchives
  * @property-read int|null $versions_count
  * @property-read Collection<int, PackageDownload> $downloads
  * @property-read int|null $downloads_count
@@ -95,6 +96,17 @@ class Package extends Model
     public function versions(): HasMany
     {
         return $this->hasMany(PackageVersion::class, 'package_uuid', 'uuid');
+    }
+
+    /**
+     * Every archive built for this package, across all its versions. Denormalized
+     * onto the package so files can be purged in bulk before a cascade delete.
+     *
+     * @return HasMany<DistArchive, $this>
+     */
+    public function distArchives(): HasMany
+    {
+        return $this->hasMany(DistArchive::class, 'package_uuid', 'uuid');
     }
 
     /**

--- a/app/Models/PackageVersion.php
+++ b/app/Models/PackageVersion.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Storage;
 
@@ -34,6 +35,8 @@ use Illuminate\Support\Facades\Storage;
  * @property Carbon|null $updated_at
  * @property-read Package $package
  * @property-read Collection<int, SecurityAdvisoryMatch> $advisoryMatches
+ * @property-read Collection<int, DistArchive> $archives
+ * @property-read DistArchive|null $currentArchive
  *
  * @method static Builder<static>|PackageVersion dev()
  * @method static \Database\Factories\PackageVersionFactory factory($count = null, $state = [])
@@ -74,8 +77,16 @@ class PackageVersion extends Model
     protected static function booted(): void
     {
         static::deleting(function (PackageVersion $version) {
+            $disk = Storage::disk(config('pricore.dist.disk'));
+
+            // A version owns every archive ever built for it, not just the one
+            // dist_path points at. The rows themselves go by foreign key cascade.
+            foreach ($version->archives as $archive) {
+                $disk->delete($archive->path);
+            }
+
             if ($version->dist_path) {
-                Storage::disk(config('pricore.dist.disk'))->delete($version->dist_path);
+                $disk->delete($version->dist_path);
             }
         });
     }
@@ -94,6 +105,23 @@ class PackageVersion extends Model
     public function advisoryMatches(): HasMany
     {
         return $this->hasMany(SecurityAdvisoryMatch::class, 'package_version_uuid', 'uuid');
+    }
+
+    /**
+     * @return HasMany<DistArchive, $this>
+     */
+    public function archives(): HasMany
+    {
+        return $this->hasMany(DistArchive::class, 'package_version_uuid', 'uuid');
+    }
+
+    /**
+     * @return HasOne<DistArchive, $this>
+     */
+    public function currentArchive(): HasOne
+    {
+        return $this->hasOne(DistArchive::class, 'package_version_uuid', 'uuid')
+            ->whereNull('detached_at');
     }
 
     /**

--- a/config/pricore.php
+++ b/config/pricore.php
@@ -6,6 +6,11 @@ return [
         'enabled' => env('DIST_ENABLED', true),
         'disk' => env('DIST_DISK', 'local'),
         'signed_url_expiry' => env('DIST_SIGNED_URL_EXPIRY', 30), // minutes, for S3
+
+        // Days to keep archives a branch has moved past, counted from when they
+        // stopped being current. Unset keeps them indefinitely, so lock files
+        // pinning older commits stay installable.
+        'keep_detached_days' => env('DIST_KEEP_DETACHED_DAYS'),
     ],
 
 ];

--- a/database/factories/DistArchiveFactory.php
+++ b/database/factories/DistArchiveFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DistArchive;
+use App\Models\PackageVersion;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
+
+/**
+ * @extends Factory<DistArchive>
+ */
+class DistArchiveFactory extends Factory
+{
+    protected $model = DistArchive::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $packageVersion = PackageVersion::factory();
+
+        return [
+            'package_uuid' => fn (array $attributes) => PackageVersion::find($attributes['package_version_uuid'])?->package_uuid,
+            'package_version_uuid' => $packageVersion,
+            'source_reference' => fake()->sha1(),
+            'path' => fake()->slug().'.zip',
+            'shasum' => fake()->sha1(),
+            'size' => fake()->numberBetween(1024, 1024 * 1024),
+            'detached_at' => null,
+        ];
+    }
+
+    public function forPackageVersion(PackageVersion $packageVersion): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'package_uuid' => $packageVersion->package_uuid,
+            'package_version_uuid' => $packageVersion->uuid,
+            'source_reference' => $packageVersion->source_reference ?? fake()->sha1(),
+        ]);
+    }
+
+    public function detached(?Carbon $detachedAt = null): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'detached_at' => $detachedAt ?? now(),
+        ]);
+    }
+}

--- a/database/migrations/2026_08_29_000001_create_dist_archives_table.php
+++ b/database/migrations/2026_08_29_000001_create_dist_archives_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('dist_archives', function (Blueprint $table) {
+            $table->uuid()->primary();
+            $table->foreignUuid('package_uuid')->constrained('packages', 'uuid')->cascadeOnDelete();
+            $table->foreignUuid('package_version_uuid')->constrained('package_versions', 'uuid')->cascadeOnDelete();
+            $table->string('source_reference');
+            $table->string('path');
+            $table->string('shasum')->nullable();
+            $table->unsignedBigInteger('size')->nullable();
+            $table->timestamp('detached_at')->nullable();
+            $table->timestamps();
+
+            // Named explicitly: the generated name exceeds the 63-byte identifier
+            // limit PostgreSQL silently truncates at.
+            $table->unique(['package_version_uuid', 'source_reference'], 'dist_archives_version_reference_unique');
+
+            // MySQL indexes foreign keys automatically, PostgreSQL and SQLite do not.
+            $table->index('package_uuid');
+            $table->index('detached_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('dist_archives');
+    }
+};

--- a/database/migrations/2026_08_29_000002_backfill_dist_archives.php
+++ b/database/migrations/2026_08_29_000002_backfill_dist_archives.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    /**
+     * Record an archive row for every version that already has one on disk.
+     *
+     * Idempotent so an interrupted run can simply be repeated. Reads no files:
+     * shasum and size come from the columns, both of which are legitimately null
+     * for older rows.
+     */
+    public function up(): void
+    {
+        DB::table('package_versions')
+            ->whereNotNull('dist_path')
+            ->whereNotNull('source_reference')
+            ->chunkById(500, function ($packageVersions) {
+                $alreadyRecorded = DB::table('dist_archives')
+                    ->whereIn('package_version_uuid', collect($packageVersions)->pluck('uuid'))
+                    ->pluck('package_version_uuid')
+                    ->all();
+
+                $rows = collect($packageVersions)
+                    ->reject(fn ($packageVersion) => in_array($packageVersion->uuid, $alreadyRecorded, true))
+                    ->map(fn ($packageVersion) => [
+                        'uuid' => (string) Str::uuid(),
+                        'package_uuid' => $packageVersion->package_uuid,
+                        'package_version_uuid' => $packageVersion->uuid,
+                        'source_reference' => $packageVersion->source_reference,
+                        'path' => $packageVersion->dist_path,
+                        'shasum' => $packageVersion->dist_shasum,
+                        'size' => $packageVersion->dist_size,
+                        // Every backfilled archive is the current one for its
+                        // version, so nothing becomes prunable on upgrade.
+                        'detached_at' => null,
+                        'created_at' => $packageVersion->created_at,
+                        'updated_at' => $packageVersion->updated_at,
+                    ])
+                    ->all();
+
+                if ($rows !== []) {
+                    DB::table('dist_archives')->insert($rows);
+                }
+            }, 'uuid');
+    }
+
+    public function down(): void
+    {
+        // The table itself is dropped by the migration that created it.
+    }
+};

--- a/docs/guide/dist-mirroring.md
+++ b/docs/guide/dist-mirroring.md
@@ -25,6 +25,7 @@ When disabled, Pricore serves only `source` references and Composer falls back t
 | `DIST_ENABLED` | Enable or disable dist archive creation | `true` |
 | `DIST_DISK` | Storage disk for archives (`local` or `s3`) | `local` |
 | `DIST_SIGNED_URL_EXPIRY` | Signed URL expiry in minutes (S3 only) | `30` |
+| `DIST_KEEP_DETACHED_DAYS` | Days to keep archives a branch has moved past | unset (keep forever) |
 
 ### Local Storage
 
@@ -59,13 +60,37 @@ Dist archive creation depends on your Git provider's capabilities:
 
 When a provider does not support archive downloads, the sync continues normally — packages are served with `source` references only.
 
+## Branch Versions and Lock Files
+
+Tags are immutable, but branches move. When a branch like `main` receives a new commit, Pricore builds a fresh archive for it — and keeps the previous one.
+
+This matters for `composer install`. A `composer.lock` pins the exact commit that was resolved, and `install` downloads that commit specifically rather than re-reading metadata. If the older archive were discarded when the branch moved, every lock file pinning it would fail to install until someone ran `composer update`.
+
+So each archive is recorded against its own commit. When a branch moves on, the previous archive is marked **detached**: no longer what the branch resolves to, but still downloadable by the commit that named it.
+
 ## Archive Retention
 
-By default, Pricore keeps dist archives for all versions. You can configure per-package retention to automatically clean up old archives and save disk space.
+By default, Pricore keeps dist archives for all versions, including detached ones. Two settings control cleanup, both applied by the `dist:cleanup` command.
 
-The `dist_keep_last_releases` setting on each package controls how many stable release archives to keep. When set to a value greater than `0`, the `dist:cleanup` command removes archives for older stable versions while keeping the most recent ones.
+### Stable releases
+
+The `dist_keep_last_releases` setting on each package controls how many stable release archives to keep. When set to a value greater than `0`, `dist:cleanup` removes archives for older stable versions while keeping the most recent ones.
 
 For example, if `dist_keep_last_releases` is set to `5`, only the 5 most recent stable version archives are kept. Dev versions and pre-release versions are not affected.
+
+### Detached branch archives
+
+`DIST_KEEP_DETACHED_DAYS` bounds how long archives are kept after their branch moves past them:
+
+```bash
+DIST_KEEP_DETACHED_DAYS=30
+```
+
+The window is measured from when an archive **stopped being current**, not from when it was built — a long-lived branch archive superseded yesterday is kept for the full window regardless of its age.
+
+::: warning
+Leaving this unset keeps every detached archive indefinitely, which is the safe default: any commit ever synced stays installable. Setting it trades that guarantee for disk space. Lock files pinning a commit older than the window will fail to install.
+:::
 
 ### Running Cleanup
 
@@ -116,5 +141,12 @@ Composer prefers `dist` over `source` by default, so installs automatically use 
 ### Disk space growing
 
 - Configure `dist_keep_last_releases` on packages with many releases
-- Schedule `php artisan dist:cleanup` to run daily
+- Set `DIST_KEEP_DETACHED_DAYS` to bound archives from moved branches
+- Schedule `php artisan dist:cleanup` to run daily — it is not scheduled by default
 - Consider using S3 storage for large registries
+
+### `composer install` fails with 404 on a branch version
+
+The lock file pins a commit whose archive is no longer stored. This happens when
+`DIST_KEEP_DETACHED_DAYS` is set and the commit fell outside the window. Either
+raise the window, or run `composer update` to move the lock to the current head.

--- a/tests/Feature/Composer/DistDownloadAfterBranchSyncTest.php
+++ b/tests/Feature/Composer/DistDownloadAfterBranchSyncTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use App\Domains\Repository\Actions\SyncRefAction;
+use App\Domains\Repository\Contracts\Data\RefData;
+use App\Domains\Repository\Contracts\Interfaces\GitProviderInterface;
+use App\Models\AccessToken;
+use App\Models\DistArchive;
+use App\Models\Organization;
+use App\Models\PackageVersion;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach(function () {
+    Storage::fake('local');
+
+    $this->user = User::factory()->create();
+    $this->organization = Organization::factory()->create([
+        'slug' => 'acme',
+        'owner_uuid' => $this->user->uuid,
+    ]);
+    $this->repository = Repository::factory()
+        ->github()
+        ->forOrganization($this->organization)
+        ->create();
+
+    $this->plainToken = 'test-token-'.uniqid();
+    AccessToken::factory()
+        ->forOrganization($this->organization)
+        ->withPlainToken($this->plainToken)
+        ->neverExpires()
+        ->create();
+
+    $this->syncBranch = function (string $commit): string {
+        $provider = Mockery::mock(GitProviderInterface::class);
+
+        $provider->shouldReceive('getFileContent')
+            ->andReturnUsing(fn (string $ref, string $path) => $path === 'composer.json'
+                ? json_encode(['name' => 'acme/test-package', 'type' => 'library'])
+                : null);
+        $provider->shouldReceive('getRepositoryUrl')
+            ->andReturn('https://github.com/acme/test-package.git');
+        $provider->shouldReceive('getRepositoryIdentifier')
+            ->andReturn('acme/test-package');
+        $provider->shouldReceive('downloadArchive')
+            ->andReturnUsing(function (string $ref, string $outputPath) use ($commit) {
+                file_put_contents($outputPath, "zip-for-{$commit}");
+
+                return true;
+            });
+
+        return app(SyncRefAction::class)->handle(
+            $provider,
+            $this->repository,
+            new RefData(name: 'main', commit: $commit),
+        );
+    };
+});
+
+it('keeps a locked branch commit installable after the branch head moves', function () {
+    $lockedCommit = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    $newCommit = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+    expect(($this->syncBranch)($lockedCommit))->toBe('added');
+    expect(($this->syncBranch)($newCommit))->toBe('updated');
+
+    // The branch keeps a single row, so it now points at the new head.
+    $packageVersion = PackageVersion::query()->sole();
+    expect($packageVersion->version)->toBe('dev-main')
+        ->and($packageVersion->source_reference)->toBe($newCommit);
+
+    $response = test()->withHeaders([
+        'Authorization' => "Bearer {$this->plainToken}",
+        'Accept' => 'application/json',
+    ])->get("/acme/dists/acme/test-package/dev-main/{$lockedCommit}.zip");
+
+    $response->assertOk();
+
+    expect($response->streamedContent())->toBe("zip-for-{$lockedCommit}");
+
+    // Both archives are recorded; only the superseded one is detached.
+    expect(DistArchive::query()->count())->toBe(2);
+
+    expect(DistArchive::query()->where('source_reference', $lockedCommit)->sole()->detached_at)
+        ->not->toBeNull();
+    expect(DistArchive::query()->where('source_reference', $newCommit)->sole()->detached_at)
+        ->toBeNull();
+
+    // Metadata advertises the new head, so a fresh resolve moves forward.
+    expect($packageVersion->dist_url)->toContain($newCommit);
+});

--- a/tests/Feature/Composer/DistDownloadTest.php
+++ b/tests/Feature/Composer/DistDownloadTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\AccessToken;
+use App\Models\DistArchive;
 use App\Models\Organization;
 use App\Models\Package;
 use App\Models\PackageVersion;
@@ -112,10 +113,12 @@ it('downloads a dist archive for a branch version with slashes', function () {
         ->for($this->organization, 'organization')
         ->create(['name' => 'acme/test-package']);
 
-    $distPath = 'acme/acme/test-package/dev-feat_ISSUE-123-my-feature_abc123def456.zip';
+    // A slash in the branch name becomes a directory separator in the archive
+    // path, exactly as DistArchiveData::pathFor() writes it.
+    $distPath = 'acme/acme/test-package/dev-feat/ISSUE-123-my-feature_abc123def456.zip';
     Storage::disk('local')->put($distPath, 'fake-zip-content');
 
-    PackageVersion::factory()
+    $packageVersion = PackageVersion::factory()
         ->for($package)
         ->create([
             'version' => 'dev-feat/ISSUE-123-my-feature',
@@ -124,6 +127,11 @@ it('downloads a dist archive for a branch version with slashes', function () {
             'dist_path' => $distPath,
             'dist_shasum' => sha1('fake-zip-content'),
         ]);
+
+    DistArchive::factory()->forPackageVersion($packageVersion)->create([
+        'path' => $distPath,
+        'shasum' => sha1('fake-zip-content'),
+    ]);
 
     $response = distGet('/acme/dists/acme/test-package/dev-feat/ISSUE-123-my-feature/abc123def456.zip', $this->plainToken);
 
@@ -197,6 +205,133 @@ it('returns 404 for a legacy version request with a non-matching reference', fun
     $response = distGet('/acme/dists/acme/test-package/1.2.0/0123456789ab.zip', $this->plainToken);
 
     $response->assertNotFound();
+});
+
+it('serves the archive for a commit the branch has already moved past', function () {
+    $package = Package::factory()
+        ->for($this->organization, 'organization')
+        ->create(['name' => 'acme/test-package']);
+
+    // The branch head has moved on, so the version row points at the new commit
+    // while the archive built for the locked commit is still on disk.
+    Storage::disk('local')->put('acme/acme/test-package/dev-main_aaaaaaaaaaaa.zip', 'old-zip-content');
+    Storage::disk('local')->put('acme/acme/test-package/dev-main_bbbbbbbbbbbb.zip', 'new-zip-content');
+
+    PackageVersion::factory()
+        ->for($package)
+        ->create([
+            'version' => 'dev-main',
+            'source_reference' => 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            'dist_url' => url('/acme/dists/acme/test-package/dev-main/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.zip'),
+            'dist_path' => 'acme/acme/test-package/dev-main_bbbbbbbbbbbb.zip',
+            'dist_shasum' => sha1('new-zip-content'),
+        ]);
+
+    $response = distGet('/acme/dists/acme/test-package/dev-main/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.zip', $this->plainToken);
+
+    $response->assertOk();
+
+    expect($response->streamedContent())->toBe('old-zip-content');
+});
+
+it('returns 404 when the archive for an older commit is gone from disk', function () {
+    $package = Package::factory()
+        ->for($this->organization, 'organization')
+        ->create(['name' => 'acme/test-package']);
+
+    Storage::disk('local')->put('acme/acme/test-package/dev-main_bbbbbbbbbbbb.zip', 'new-zip-content');
+
+    PackageVersion::factory()
+        ->for($package)
+        ->create([
+            'version' => 'dev-main',
+            'source_reference' => 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            'dist_url' => url('/acme/dists/acme/test-package/dev-main/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.zip'),
+            'dist_path' => 'acme/acme/test-package/dev-main_bbbbbbbbbbbb.zip',
+            'dist_shasum' => sha1('new-zip-content'),
+        ]);
+
+    $response = distGet('/acme/dists/acme/test-package/dev-main/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.zip', $this->plainToken);
+
+    $response->assertNotFound();
+});
+
+it('serves an archive whose version row no longer records a dist path', function () {
+    $package = Package::factory()
+        ->for($this->organization, 'organization')
+        ->create(['name' => 'acme/test-package']);
+
+    Storage::disk('local')->put('acme/acme/test-package/dev-main_aaaaaaaaaaaa.zip', 'old-zip-content');
+
+    PackageVersion::factory()
+        ->for($package)
+        ->create([
+            'version' => 'dev-main',
+            'source_reference' => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            'dist_url' => null,
+            'dist_path' => null,
+            'dist_shasum' => null,
+        ]);
+
+    $response = distGet('/acme/dists/acme/test-package/dev-main/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.zip', $this->plainToken);
+
+    $response->assertOk();
+
+    expect($response->streamedContent())->toBe('old-zip-content');
+});
+
+it('does not serve archives belonging to another organization', function () {
+    $otherOrganization = Organization::factory()->create([
+        'slug' => 'other',
+        'owner_uuid' => $this->user->uuid,
+    ]);
+
+    $package = Package::factory()
+        ->for($otherOrganization, 'organization')
+        ->create(['name' => 'acme/test-package']);
+
+    Storage::disk('local')->put('other/acme/test-package/dev-main_aaaaaaaaaaaa.zip', 'other-org-content');
+
+    PackageVersion::factory()
+        ->for($package)
+        ->create([
+            'version' => 'dev-main',
+            'source_reference' => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            'dist_path' => 'other/acme/test-package/dev-main_aaaaaaaaaaaa.zip',
+        ]);
+
+    $response = distGet('/acme/dists/acme/test-package/dev-main/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.zip', $this->plainToken);
+
+    $response->assertNotFound();
+});
+
+it('resolves through the archive row rather than the version pointer', function () {
+    $package = Package::factory()
+        ->for($this->organization, 'organization')
+        ->create(['name' => 'acme/test-package']);
+
+    Storage::disk('local')->put('acme/recorded.zip', 'recorded-content');
+    Storage::disk('local')->put('acme/pointer.zip', 'pointer-content');
+
+    $packageVersion = PackageVersion::factory()
+        ->for($package)
+        ->create([
+            'version' => 'dev-main',
+            'source_reference' => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            'dist_path' => 'acme/pointer.zip',
+            'dist_shasum' => sha1('pointer-content'),
+        ]);
+
+    DistArchive::factory()->forPackageVersion($packageVersion)->create([
+        'path' => 'acme/recorded.zip',
+        'shasum' => sha1('recorded-content'),
+    ]);
+
+    $response = distGet('/acme/dists/acme/test-package/dev-main/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.zip', $this->plainToken);
+
+    $response->assertOk();
+
+    expect($response->streamedContent())->toBe('recorded-content');
 });
 
 it('requires authentication for dist download', function () {

--- a/tests/Feature/Domains/Mirror/SyncMirrorVersionDistTest.php
+++ b/tests/Feature/Domains/Mirror/SyncMirrorVersionDistTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use App\Domains\Mirror\Jobs\SyncMirrorVersionJob;
+use App\Domains\Repository\Contracts\Enums\RepositorySyncStatus;
+use App\Models\DistArchive;
+use App\Models\Mirror;
+use App\Models\Organization;
+use App\Models\PackageVersion;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach(function () {
+    Storage::fake('local');
+
+    $this->organization = Organization::factory()->create(['slug' => 'acme']);
+    $this->mirror = Mirror::factory()->create([
+        'organization_uuid' => $this->organization->uuid,
+        'url' => 'https://satis.example.com',
+        'mirror_dist' => true,
+        'sync_status' => RepositorySyncStatus::Pending,
+    ]);
+
+    // Http::fake() merges stubs rather than replacing them, so the upstream
+    // state lives here and the stub reads it on every request.
+    $this->upstream = new stdClass;
+    $this->upstream->reference = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    $this->upstream->body = 'zip-one';
+
+    $upstream = $this->upstream;
+
+    Http::fake(function (Request $request) use ($upstream) {
+        if (str_contains($request->url(), 'packages.json')) {
+            return Http::response([
+                'packages' => [
+                    'vendor/pkg' => [
+                        'dev-main' => [
+                            'name' => 'vendor/pkg',
+                            'version' => 'dev-main',
+                            'dist' => [
+                                'reference' => $upstream->reference,
+                                'url' => 'https://satis.example.com/dists/vendor/pkg/dev-main.zip',
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
+        }
+
+        return Http::response($upstream->body);
+    });
+});
+
+it('re-mirrors a dev version when its upstream reference moves', function () {
+    $firstReference = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    $secondReference = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+    SyncMirrorVersionJob::dispatchSync($this->mirror, 'vendor/pkg', 'dev-main');
+
+    $packageVersion = PackageVersion::query()->sole();
+    expect($packageVersion->dist_shasum)->toBe(sha1('zip-one'));
+
+    $this->upstream->reference = $secondReference;
+    $this->upstream->body = 'zip-two';
+
+    SyncMirrorVersionJob::dispatchSync($this->mirror, 'vendor/pkg', 'dev-main');
+
+    $packageVersion->refresh();
+
+    // The pointer follows the new reference instead of keeping the old archive.
+    expect($packageVersion->source_reference)->toBe($secondReference)
+        ->and($packageVersion->dist_shasum)->toBe(sha1('zip-two'))
+        ->and($packageVersion->dist_url)->toContain($secondReference);
+
+    expect(DistArchive::query()->count())->toBe(2);
+
+    $firstArchive = DistArchive::query()->where('source_reference', $firstReference)->sole();
+    $secondArchive = DistArchive::query()->where('source_reference', $secondReference)->sole();
+
+    expect($firstArchive->detached_at)->not->toBeNull()
+        ->and($secondArchive->detached_at)->toBeNull();
+
+    // The superseded archive stays on disk so locked commits still install.
+    Storage::disk('local')->assertExists($firstArchive->path);
+    Storage::disk('local')->assertExists($secondArchive->path);
+});
+
+it('does not re-download when the upstream reference is unchanged', function () {
+    SyncMirrorVersionJob::dispatchSync($this->mirror, 'vendor/pkg', 'dev-main');
+
+    $this->upstream->body = 'zip-replaced';
+
+    SyncMirrorVersionJob::dispatchSync($this->mirror, 'vendor/pkg', 'dev-main');
+
+    expect(DistArchive::query()->count())->toBe(1)
+        ->and(PackageVersion::query()->sole()->dist_shasum)->toBe(sha1('zip-one'));
+});

--- a/tests/Feature/Domains/Repository/CleanupDistArchivesActionTest.php
+++ b/tests/Feature/Domains/Repository/CleanupDistArchivesActionTest.php
@@ -1,0 +1,157 @@
+<?php
+
+use App\Domains\Repository\Actions\CleanupDistArchivesAction;
+use App\Models\DistArchive;
+use App\Models\Organization;
+use App\Models\Package;
+use App\Models\PackageVersion;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach(function () {
+    Storage::fake('local');
+
+    $this->organization = Organization::factory()->create(['slug' => 'acme']);
+    $this->package = Package::factory()
+        ->for($this->organization, 'organization')
+        ->create(['name' => 'acme/test-package', 'dist_keep_last_releases' => 0]);
+
+    $this->archiveFor = function (PackageVersion $packageVersion, string $path, ?CarbonInterface $detachedAt = null) {
+        Storage::disk('local')->put($path, 'zip');
+
+        return DistArchive::factory()
+            ->forPackageVersion($packageVersion)
+            ->create([
+                'path' => $path,
+                'detached_at' => $detachedAt,
+                'source_reference' => $packageVersion->source_reference,
+            ]);
+    };
+
+    $this->cleanup = fn () => app(CleanupDistArchivesAction::class)->handle();
+});
+
+it('keeps detached archives when no retention window is configured', function () {
+    config(['pricore.dist.keep_detached_days' => null]);
+
+    $packageVersion = PackageVersion::factory()->for($this->package)->create([
+        'version' => 'dev-main',
+        'source_reference' => 'bbbbbbbbbbbb',
+    ]);
+
+    $detached = DistArchive::factory()->forPackageVersion($packageVersion)->create([
+        'source_reference' => 'aaaaaaaaaaaa',
+        'path' => 'acme/acme/test-package/dev-main_aaaaaaaaaaaa.zip',
+        'detached_at' => now()->subYears(2),
+    ]);
+    Storage::disk('local')->put($detached->path, 'zip');
+
+    $result = ($this->cleanup)();
+
+    expect($result['detached_removed'])->toBe(0)
+        ->and(DistArchive::query()->whereKey($detached->uuid)->exists())->toBeTrue();
+
+    Storage::disk('local')->assertExists($detached->path);
+});
+
+it('removes detached archives past the retention window', function () {
+    config(['pricore.dist.keep_detached_days' => 30]);
+
+    $packageVersion = PackageVersion::factory()->for($this->package)->create([
+        'version' => 'dev-main',
+        'source_reference' => 'cccccccccccc',
+    ]);
+
+    $stale = ($this->archiveFor)($packageVersion, 'acme/old.zip', now()->subDays(45));
+    $stale->update(['source_reference' => 'aaaaaaaaaaaa']);
+
+    $recent = ($this->archiveFor)($packageVersion, 'acme/recent.zip', now()->subDays(5));
+    $recent->update(['source_reference' => 'bbbbbbbbbbbb']);
+
+    $result = ($this->cleanup)();
+
+    expect($result['detached_removed'])->toBe(1)
+        ->and(DistArchive::query()->whereKey($stale->uuid)->exists())->toBeFalse()
+        ->and(DistArchive::query()->whereKey($recent->uuid)->exists())->toBeTrue();
+
+    Storage::disk('local')->assertMissing('acme/old.zip');
+    Storage::disk('local')->assertExists('acme/recent.zip');
+});
+
+it('measures retention from when an archive detached, not when it was built', function () {
+    config(['pricore.dist.keep_detached_days' => 30]);
+
+    $packageVersion = PackageVersion::factory()->for($this->package)->create([
+        'version' => 'dev-main',
+        'source_reference' => 'cccccccccccc',
+    ]);
+
+    // Built long ago on a slow-moving branch, but only superseded yesterday:
+    // someone's lock file may well still pin it.
+    $archive = ($this->archiveFor)($packageVersion, 'acme/long-lived.zip', now()->subDay());
+    $archive->update(['source_reference' => 'aaaaaaaaaaaa', 'created_at' => now()->subDays(90)]);
+
+    ($this->cleanup)();
+
+    expect(DistArchive::query()->whereKey($archive->uuid)->exists())->toBeTrue();
+    Storage::disk('local')->assertExists('acme/long-lived.zip');
+});
+
+it('repairs archives whose version moved on without detaching them', function () {
+    config(['pricore.dist.keep_detached_days' => null]);
+
+    $packageVersion = PackageVersion::factory()->for($this->package)->create([
+        'version' => 'dev-main',
+        'source_reference' => 'aaaaaaaaaaaa',
+    ]);
+
+    $archive = ($this->archiveFor)($packageVersion, 'acme/drifted.zip');
+
+    $packageVersion->update([
+        'dist_path' => 'acme/drifted.zip',
+        'dist_url' => url('/acme/dists/acme/test-package/dev-main/aaaaaaaaaaaa.zip'),
+        'dist_shasum' => 'sha',
+        'dist_size' => 10,
+    ]);
+
+    // The reference moves without the funnel, mimicking a sync that died between
+    // the two writes.
+    $packageVersion->updateQuietly(['source_reference' => 'bbbbbbbbbbbb']);
+
+    $result = ($this->cleanup)();
+
+    expect($result['detached_marked'])->toBe(1)
+        ->and(DistArchive::query()->whereKey($archive->uuid)->sole()->detached_at)->not->toBeNull();
+
+    $packageVersion->refresh();
+
+    expect($packageVersion->dist_path)->toBeNull()
+        ->and($packageVersion->dist_url)->toBeNull()
+        ->and($packageVersion->dist_shasum)->toBeNull()
+        ->and($packageVersion->dist_size)->toBeNull();
+});
+
+it('still prunes stable releases beyond the per-package keep count', function () {
+    config(['pricore.dist.keep_detached_days' => null]);
+
+    $this->package->update(['dist_keep_last_releases' => 1]);
+
+    foreach ([['1.0.0', '1.0.0.0'], ['2.0.0', '2.0.0.0']] as [$version, $normalized]) {
+        $packageVersion = PackageVersion::factory()->for($this->package)->create([
+            'version' => $version,
+            'normalized_version' => $normalized,
+            'source_reference' => "ref-{$version}",
+            'dist_path' => "acme/{$version}.zip",
+        ]);
+
+        ($this->archiveFor)($packageVersion, "acme/{$version}.zip");
+    }
+
+    $result = ($this->cleanup)();
+
+    expect($result['archives_removed'])->toBe(1);
+
+    Storage::disk('local')->assertExists('acme/2.0.0.zip');
+    Storage::disk('local')->assertMissing('acme/1.0.0.zip');
+    expect(DistArchive::query()->count())->toBe(1);
+});

--- a/tests/Feature/Domains/Repository/DistArchiveBackfillTest.php
+++ b/tests/Feature/Domains/Repository/DistArchiveBackfillTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use App\Models\DistArchive;
+use App\Models\Organization;
+use App\Models\Package;
+use App\Models\PackageVersion;
+
+beforeEach(function () {
+    $this->organization = Organization::factory()->create(['slug' => 'acme']);
+    $this->package = Package::factory()
+        ->for($this->organization, 'organization')
+        ->create(['name' => 'acme/test-package']);
+
+    $this->runBackfill = function () {
+        $migration = require database_path('migrations/2026_08_29_000002_backfill_dist_archives.php');
+
+        $migration->up();
+    };
+});
+
+it('records an archive for every version that already has one', function () {
+    $packageVersion = PackageVersion::factory()->for($this->package)->create([
+        'version' => '1.0.0',
+        'source_reference' => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        'dist_path' => 'acme/acme/test-package/1.0.0_aaaaaaaaaaaa.zip',
+        'dist_shasum' => 'sha-one',
+        'dist_size' => 512,
+    ]);
+
+    ($this->runBackfill)();
+
+    $archive = DistArchive::query()->sole();
+
+    expect($archive->package_version_uuid)->toBe($packageVersion->uuid)
+        ->and($archive->package_uuid)->toBe($this->package->uuid)
+        ->and($archive->source_reference)->toBe('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+        ->and($archive->path)->toBe('acme/acme/test-package/1.0.0_aaaaaaaaaaaa.zip')
+        ->and($archive->shasum)->toBe('sha-one')
+        ->and($archive->size)->toBe(512)
+        // Nothing becomes prunable on upgrade.
+        ->and($archive->detached_at)->toBeNull();
+});
+
+it('tolerates versions missing a shasum or size', function () {
+    PackageVersion::factory()->for($this->package)->create([
+        'version' => '1.0.0',
+        'source_reference' => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        'dist_path' => 'acme/one.zip',
+        'dist_shasum' => null,
+        'dist_size' => null,
+    ]);
+
+    ($this->runBackfill)();
+
+    $archive = DistArchive::query()->sole();
+
+    expect($archive->shasum)->toBeNull()
+        ->and($archive->size)->toBeNull();
+});
+
+it('skips versions without an archive on disk', function () {
+    PackageVersion::factory()->for($this->package)->create([
+        'version' => '1.0.0',
+        'source_reference' => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        'dist_path' => null,
+    ]);
+
+    PackageVersion::factory()->for($this->package)->create([
+        'version' => '2.0.0',
+        'source_reference' => null,
+        'dist_path' => 'acme/orphan.zip',
+    ]);
+
+    ($this->runBackfill)();
+
+    expect(DistArchive::query()->count())->toBe(0);
+});
+
+it('can be run again without duplicating rows', function () {
+    PackageVersion::factory()->for($this->package)->create([
+        'version' => '1.0.0',
+        'source_reference' => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        'dist_path' => 'acme/one.zip',
+        'dist_shasum' => 'sha-one',
+        'dist_size' => 512,
+    ]);
+
+    ($this->runBackfill)();
+    ($this->runBackfill)();
+
+    expect(DistArchive::query()->count())->toBe(1);
+});

--- a/tests/Feature/Domains/Repository/DistArchiveDeletionTest.php
+++ b/tests/Feature/Domains/Repository/DistArchiveDeletionTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use App\Domains\Repository\Actions\RemoveStaleVersionsAction;
+use App\Domains\Repository\Contracts\Data\RefData;
+use App\Domains\Repository\Contracts\Data\RefsCollectionData;
+use App\Models\DistArchive;
+use App\Models\Organization;
+use App\Models\Package;
+use App\Models\PackageVersion;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Spatie\LaravelData\DataCollection;
+
+beforeEach(function () {
+    Storage::fake('local');
+
+    $this->user = User::factory()->create();
+    $this->organization = Organization::factory()->create([
+        'slug' => 'acme',
+        'owner_uuid' => $this->user->uuid,
+    ]);
+    $this->organization->members()->attach($this->user->uuid, [
+        'role' => 'owner',
+        'uuid' => (string) Str::uuid(),
+    ]);
+
+    $this->repository = Repository::factory()
+        ->github()
+        ->forOrganization($this->organization)
+        ->create();
+    $this->package = Package::factory()
+        ->for($this->organization, 'organization')
+        ->forRepository($this->repository)
+        ->create(['name' => 'acme/test-package']);
+
+    $this->versionWithArchives = function (string $version, array $paths): PackageVersion {
+        $packageVersion = PackageVersion::factory()->for($this->package)->create([
+            'version' => $version,
+            'source_reference' => "ref-{$version}",
+            'dist_path' => $paths[0],
+        ]);
+
+        foreach ($paths as $index => $path) {
+            Storage::disk('local')->put($path, 'zip');
+
+            DistArchive::factory()->forPackageVersion($packageVersion)->create([
+                'path' => $path,
+                'source_reference' => "ref-{$version}-{$index}",
+                'detached_at' => $index === 0 ? null : now(),
+            ]);
+        }
+
+        return $packageVersion;
+    };
+});
+
+it('deletes every archive file when a version is removed as stale', function () {
+    ($this->versionWithArchives)('dev-gone', ['acme/gone-current.zip', 'acme/gone-old.zip']);
+    ($this->versionWithArchives)('dev-main', ['acme/main.zip']);
+
+    $refs = new RefsCollectionData(
+        tags: new DataCollection(RefData::class, []),
+        branches: new DataCollection(RefData::class, [new RefData(name: 'main', commit: 'abc')]),
+        all: new DataCollection(RefData::class, [new RefData(name: 'main', commit: 'abc')]),
+    );
+
+    $removed = app(RemoveStaleVersionsAction::class)->handle($this->repository, $refs);
+
+    expect($removed)->toBe(1);
+
+    // Both archives for the removed version go, not only the one dist_path named.
+    Storage::disk('local')->assertMissing('acme/gone-current.zip');
+    Storage::disk('local')->assertMissing('acme/gone-old.zip');
+    Storage::disk('local')->assertExists('acme/main.zip');
+
+    expect(DistArchive::query()->count())->toBe(1);
+});
+
+it('deletes archive files when a package is deleted', function () {
+    ($this->versionWithArchives)('dev-main', ['acme/main-current.zip', 'acme/main-old.zip']);
+
+    $this->actingAs($this->user)
+        ->delete(route('organizations.packages.destroy', [$this->organization, $this->package]))
+        ->assertRedirect();
+
+    Storage::disk('local')->assertMissing('acme/main-current.zip');
+    Storage::disk('local')->assertMissing('acme/main-old.zip');
+    expect(DistArchive::query()->count())->toBe(0);
+});
+
+it('deletes archive files when a repository is deleted', function () {
+    ($this->versionWithArchives)('dev-main', ['acme/main-current.zip', 'acme/main-old.zip']);
+
+    $this->actingAs($this->user)
+        ->delete(route('organizations.repositories.destroy', [$this->organization, $this->repository]))
+        ->assertRedirect();
+
+    // Packages, versions and rows all cascade in the database, so the files have
+    // to be cleared before the rows vanish.
+    Storage::disk('local')->assertMissing('acme/main-current.zip');
+    Storage::disk('local')->assertMissing('acme/main-old.zip');
+    expect(DistArchive::query()->count())->toBe(0);
+});

--- a/tests/Feature/Domains/Repository/RecordDistArchiveActionTest.php
+++ b/tests/Feature/Domains/Repository/RecordDistArchiveActionTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use App\Domains\Repository\Actions\RecordDistArchiveAction;
+use App\Domains\Repository\Contracts\Data\DistArchiveData;
+use App\Models\DistArchive;
+use App\Models\Organization;
+use App\Models\Package;
+use App\Models\PackageVersion;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach(function () {
+    Storage::fake('local');
+
+    $this->organization = Organization::factory()->create(['slug' => 'acme']);
+    $this->package = Package::factory()
+        ->for($this->organization, 'organization')
+        ->create(['name' => 'acme/test-package']);
+
+    $this->record = function (PackageVersion $packageVersion, string $path, string $shasum) {
+        return app(RecordDistArchiveAction::class)->handle(
+            $packageVersion,
+            new DistArchiveData(path: $path, shasum: $shasum, size: 128),
+            'acme',
+        );
+    };
+});
+
+it('records an archive and points the version at it', function () {
+    $packageVersion = PackageVersion::factory()->for($this->package)->create([
+        'version' => 'dev-main',
+        'source_reference' => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        'dist_url' => null,
+        'dist_path' => null,
+    ]);
+
+    $archive = ($this->record)($packageVersion, 'acme/acme/test-package/dev-main_aaaaaaaaaaaa.zip', 'sha-one');
+
+    expect($archive)->not->toBeNull()
+        ->and($archive->detached_at)->toBeNull()
+        ->and($archive->package_uuid)->toBe($this->package->uuid);
+
+    $packageVersion->refresh();
+
+    expect($packageVersion->dist_path)->toBe('acme/acme/test-package/dev-main_aaaaaaaaaaaa.zip')
+        ->and($packageVersion->dist_shasum)->toBe('sha-one')
+        ->and($packageVersion->dist_size)->toBe(128)
+        ->and($packageVersion->dist_url)->toBe(
+            url('/acme/dists/acme/test-package/dev-main/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.zip')
+        );
+});
+
+it('updates in place when the same reference is recorded again', function () {
+    $packageVersion = PackageVersion::factory()->for($this->package)->create([
+        'version' => 'dev-main',
+        'source_reference' => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    ]);
+
+    ($this->record)($packageVersion, 'acme/acme/test-package/dev-main_aaaaaaaaaaaa.zip', 'sha-one');
+    ($this->record)($packageVersion, 'acme/acme/test-package/dev-main_aaaaaaaaaaaa.zip', 'sha-two');
+
+    expect(DistArchive::query()->count())->toBe(1)
+        ->and(DistArchive::query()->sole()->shasum)->toBe('sha-two');
+});
+
+it('detaches the previous archive but keeps its file', function () {
+    $packageVersion = PackageVersion::factory()->for($this->package)->create([
+        'version' => 'dev-main',
+        'source_reference' => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    ]);
+
+    $firstPath = 'acme/acme/test-package/dev-main_aaaaaaaaaaaa.zip';
+    Storage::disk('local')->put($firstPath, 'zip-one');
+    ($this->record)($packageVersion, $firstPath, 'sha-one');
+
+    // The branch moves on.
+    $packageVersion->update(['source_reference' => 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb']);
+    $secondPath = 'acme/acme/test-package/dev-main_bbbbbbbbbbbb.zip';
+    Storage::disk('local')->put($secondPath, 'zip-two');
+    ($this->record)($packageVersion, $secondPath, 'sha-two');
+
+    $first = DistArchive::query()->where('path', $firstPath)->sole();
+    $second = DistArchive::query()->where('path', $secondPath)->sole();
+
+    expect($first->detached_at)->not->toBeNull()
+        ->and($second->detached_at)->toBeNull();
+
+    // Keeping the file is the point: lock files pinning the old commit resolve.
+    Storage::disk('local')->assertExists($firstPath);
+});
+
+it('returns null when the version has no source reference', function () {
+    $packageVersion = PackageVersion::factory()->for($this->package)->create([
+        'version' => 'dev-main',
+        'source_reference' => null,
+    ]);
+
+    expect(($this->record)($packageVersion, 'some/path.zip', 'sha'))->toBeNull()
+        ->and(DistArchive::query()->count())->toBe(0);
+});

--- a/tests/Feature/Domains/Repository/SyncRefDistTest.php
+++ b/tests/Feature/Domains/Repository/SyncRefDistTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Domains\Composer\Contracts\Data\VersionMetadataData;
+use App\Domains\Repository\Actions\SyncRefAction;
+use App\Domains\Repository\Contracts\Data\RefData;
+use App\Domains\Repository\Contracts\Interfaces\GitProviderInterface;
+use App\Models\Organization;
+use App\Models\PackageVersion;
+use App\Models\Repository;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach(function () {
+    Storage::fake('local');
+
+    $this->organization = Organization::factory()->create(['slug' => 'acme']);
+    $this->repository = Repository::factory()
+        ->github()
+        ->forOrganization($this->organization)
+        ->create();
+
+    $this->syncBranch = function (string $commit, bool $archiveSucceeds = true): string {
+        $provider = Mockery::mock(GitProviderInterface::class);
+
+        $provider->shouldReceive('getFileContent')
+            ->andReturnUsing(fn (string $ref, string $path) => $path === 'composer.json'
+                ? json_encode(['name' => 'acme/test-package', 'type' => 'library'])
+                : null);
+        $provider->shouldReceive('getRepositoryUrl')
+            ->andReturn('https://github.com/acme/test-package.git');
+        $provider->shouldReceive('getRepositoryIdentifier')
+            ->andReturn('acme/test-package');
+        $provider->shouldReceive('downloadArchive')
+            ->andReturnUsing(function (string $ref, string $outputPath) use ($commit, $archiveSucceeds) {
+                if (! $archiveSucceeds) {
+                    return false;
+                }
+
+                file_put_contents($outputPath, "zip-for-{$commit}");
+
+                return true;
+            });
+
+        return app(SyncRefAction::class)->handle(
+            $provider,
+            $this->repository,
+            new RefData(name: 'main', commit: $commit),
+        );
+    };
+});
+
+it('clears the dist pointer when the branch moves but the archive cannot be built', function () {
+    $firstCommit = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    $secondCommit = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+    ($this->syncBranch)($firstCommit);
+
+    $packageVersion = PackageVersion::query()->sole();
+    expect($packageVersion->dist_shasum)->toBe(sha1("zip-for-{$firstCommit}"));
+
+    // The branch moves, but the provider cannot produce an archive this time.
+    ($this->syncBranch)($secondCommit, archiveSucceeds: false);
+
+    $packageVersion->refresh();
+
+    expect($packageVersion->source_reference)->toBe($secondCommit)
+        ->and($packageVersion->dist_url)->toBeNull()
+        ->and($packageVersion->dist_path)->toBeNull()
+        ->and($packageVersion->dist_shasum)->toBeNull()
+        ->and($packageVersion->dist_size)->toBeNull();
+
+    // Composer must fall back to source rather than being handed the previous
+    // commit's archive under the new reference.
+    expect(VersionMetadataData::fromPackageVersion($packageVersion)->toArray())
+        ->not->toHaveKey('dist');
+});


### PR DESCRIPTION
Branches move, but Pricore kept one `package_versions` row per version string and mutated it in place on every sync. Archive files are one-per-commit, so each sync wrote a new file and repointed the row, leaving the old archive on disk with nothing referencing it. `composer install` from a lock pinning an older commit then 404'd.

Archives are now recorded individually in a new `dist_archives` table, keyed by commit, so a locked commit resolves by lookup. `package_versions.dist_*` stays as a write-through cache of the current archive, with `RecordDistArchiveAction` as the only writer.

This also fixes a second, quieter bug on both sync paths: the dist columns were left describing the previous commit after `source_reference` moved, so metadata advertised the old archive — and its matching shasum — under the new reference, and Composer installed stale bytes without complaint. The pointer is now invalidated in the same transaction that moves the reference.

Fixes #178

### Notes for review

- `DIST_KEEP_DETACHED_DAYS` bounds how long superseded archives are kept, measured from when an archive stopped being current rather than when it was built. Unset by default, so upgrades keep every archive and nothing becomes prunable.
- The backfill runs as its own idempotent migration and reads no files.
- Resolution keeps the deterministic-path probe as a fallback for archives predating the backfill, which have no row. Commented with the migration name so it can be dropped later.
- Deleting stale versions, packages and repositories now removes archive files; those paths previously bypassed model events and stranded them.
- `dist:cleanup` remains unscheduled, as it was before.

### Known trade-off

Between the reference moving and the new archive being recorded, a version advertises no dist and Composer falls back to cloning. The window lasts as long as the archive download. Building the archive before the transaction would close it and is worth doing as a follow-up.

### Deliberately left out

- A `dist:reconcile` sweep for files whose version row was already destroyed. Those are recoverable by neither lookup nor path, so they are garbage collection rather than part of this fix.
- Storage accounting. The table makes `SUM(size)` possible; no UI here.
- `dist_url` still bakes in `APP_URL`. Now that `DistArchiveData::urlFor()` exists, computing it at read time is a contained change.
