### PR TITLE
fix(repository): handle deleted organization after sync

### DIFF
--- a/app/Domains/Repository/Jobs/CompleteSyncBatchJob.php
+++ b/app/Domains/Repository/Jobs/CompleteSyncBatchJob.php
@@ -123,7 +123,7 @@ class CompleteSyncBatchJob implements ShouldQueue
             return;
         }
 
-        $organization = $repository->organization;
+        $organization = $repository->organization()->first();
 
         if (! $organization) {
             Log::info('Skipping repository sync activity because organization is unavailable', [

--- a/app/Domains/Repository/Jobs/CompleteSyncBatchJob.php
+++ b/app/Domains/Repository/Jobs/CompleteSyncBatchJob.php
@@ -119,9 +119,25 @@ class CompleteSyncBatchJob implements ShouldQueue
             || $syncLog->versions_updated > 0
             || $syncLog->versions_removed > 0;
 
+        if (! $syncLog->status->isFailed() && ! $hasChanges) {
+            return;
+        }
+
+        $organization = $repository->organization;
+
+        if (! $organization) {
+            Log::info('Skipping repository sync activity because organization is unavailable', [
+                'repository_uuid' => $repository->uuid,
+                'organization_uuid' => $repository->organization_uuid,
+                'sync_log_uuid' => $syncLog->uuid,
+            ]);
+
+            return;
+        }
+
         if ($syncLog->status->isFailed()) {
             $recordActivityTask->handle(
-                organization: $repository->organization,
+                organization: $organization,
                 type: ActivityType::RepositorySyncFailed,
                 subject: $repository,
                 properties: [
@@ -134,12 +150,8 @@ class CompleteSyncBatchJob implements ShouldQueue
             return;
         }
 
-        if (! $hasChanges) {
-            return;
-        }
-
         $recordActivityTask->handle(
-            organization: $repository->organization,
+            organization: $organization,
             type: ActivityType::RepositorySynced,
             subject: $repository,
             properties: [

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -32,7 +32,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read User|null $credentialUser
- * @property-read Organization|null $organization
+ * @property-read Organization $organization
  * @property-read OrganizationSshKey|null $sshKey
  * @property-read Collection<int, Package> $packages
  * @property-read int|null $packages_count

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -32,7 +32,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read User|null $credentialUser
- * @property-read Organization $organization
+ * @property-read Organization|null $organization
  * @property-read OrganizationSshKey|null $sshKey
  * @property-read Collection<int, Package> $packages
  * @property-read int|null $packages_count

--- a/tests/Feature/Jobs/CompleteSyncBatchJobTest.php
+++ b/tests/Feature/Jobs/CompleteSyncBatchJobTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Domains\Activity\Actions\RecordActivityTask;
+use App\Domains\Repository\Jobs\CompleteSyncBatchJob;
+use App\Models\Organization;
+use App\Models\Repository;
+use App\Models\RepositorySyncLog;
+use Illuminate\Support\Facades\Log;
+
+it('skips recording activity when the organization was deleted during a repository sync', function () {
+    $organization = Organization::factory()->create();
+    $repository = Repository::factory()->for($organization)->create();
+    $syncLog = RepositorySyncLog::factory()
+        ->for($repository)
+        ->successful()
+        ->create(['versions_added' => 1]);
+
+    $organization->delete();
+    $repository->unsetRelation('organization');
+
+    Log::spy();
+
+    $recordActivityTask = Mockery::mock(RecordActivityTask::class);
+    $recordActivityTask->shouldNotReceive('handle');
+
+    $job = new CompleteSyncBatchJob($syncLog->uuid, $repository->uuid, null, 'batch-id');
+    $recordActivity = new ReflectionMethod($job, 'recordActivity');
+
+    $recordActivity->invoke($job, $repository, $syncLog, $recordActivityTask);
+
+    Log::shouldHaveReceived('info')
+        ->once()
+        ->with('Skipping repository sync activity because organization is unavailable', [
+            'repository_uuid' => $repository->uuid,
+            'organization_uuid' => $organization->uuid,
+            'sync_log_uuid' => $syncLog->uuid,
+        ]);
+});


### PR DESCRIPTION
## Summary

- skip repository sync activity recording when its organization was soft-deleted while the queued sync was running
- log the skipped activity with repository, organization, and sync-log identifiers
- add a regression test for the organization deletion race

## Verification

- php artisan test tests/Feature/ActivityLogTest.php tests/Feature/ActivityBroadcastTest.php tests/Feature/Jobs/CompleteSyncBatchJobTest.php
- vendor/bin/pint --test app/Domains/Repository/Jobs/CompleteSyncBatchJob.php app/Models/Repository.php tests/Feature/Jobs/CompleteSyncBatchJobTest.php
- vendor/bin/phpstan analyse --no-progress