### PR TITLE
feat(auth): improve hosted registration experience

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,9 @@ GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 GITHUB_REDIRECT_URI="${APP_URL}/auth/github/callback"
 
+# Optional. Set on hosted deployments to measure signup conversions.
+GOOGLE_ANALYTICS_ID=
+
 REVERB_APP_ID=
 REVERB_APP_KEY=
 REVERB_APP_SECRET=

--- a/app/Http/Controllers/Auth/GitHubAuthController.php
+++ b/app/Http/Controllers/Auth/GitHubAuthController.php
@@ -76,7 +76,13 @@ class GitHubAuthController extends Controller
 
         Auth::login($user, remember: true);
 
-        return redirect()->intended(route('dashboard'));
+        $response = redirect()->intended(route('dashboard'));
+
+        if (! $existingUser) {
+            $response->with('analytics', ['event' => 'sign_up', 'method' => 'github']);
+        }
+
+        return $response;
     }
 
     private function handleConnect(

--- a/app/Http/Controllers/Auth/GitLabAuthController.php
+++ b/app/Http/Controllers/Auth/GitLabAuthController.php
@@ -76,7 +76,13 @@ class GitLabAuthController extends Controller
 
         Auth::login($user, remember: true);
 
-        return redirect()->intended(route('dashboard'));
+        $response = redirect()->intended(route('dashboard'));
+
+        if (! $existingUser) {
+            $response->with('analytics', ['event' => 'sign_up', 'method' => 'gitlab']);
+        }
+
+        return $response;
     }
 
     private function handleConnect(

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -69,6 +69,7 @@ class HandleInertiaRequests extends Middleware
             'search' => $user ? fn () => $this->searchData($request) : new SearchData(packages: [], repositories: []),
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
             'cloud' => class_exists(PricoreCloudServiceProvider::class),
+            'analytics' => $request->session()->get('analytics'),
             'flash' => new FlashData(
                 status: $request->session()->get('status') ?? $request->session()->get('success'),
                 error: $request->session()->get('error'),

--- a/config/services.php
+++ b/config/services.php
@@ -48,4 +48,8 @@ return [
         'instance_uri' => env('GITLAB_INSTANCE_URI', 'https://gitlab.com/'),
     ],
 
+    'google_analytics' => [
+        'id' => env('GOOGLE_ANALYTICS_ID'),
+    ],
+
 ];

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -20,12 +20,33 @@ Settings.defaultLocale = 'en';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Pricore';
 
+type AnalyticsPayload = {
+    event: string;
+    method?: string;
+};
+
+const trackAnalytics = (payload?: AnalyticsPayload | null) => {
+    if (!payload) return;
+
+    const analyticsWindow = window as Window & {
+        gtag?: (...args: unknown[]) => void;
+    };
+
+    analyticsWindow.gtag?.(
+        'event',
+        payload.event,
+        payload.method ? { method: payload.method } : undefined,
+    );
+};
+
 // Handle flash messages via router events
 let previousFlash: SharedData['flash'] = null;
 
 router.on('success', (event) => {
     const props = event.detail.page.props as unknown as SharedData;
     const flash = props.flash;
+
+    trackAnalytics(props.analytics as AnalyticsPayload | null | undefined);
 
     // Only show toast if flash message is new
     if (flash?.status && flash.status !== previousFlash?.status) {
@@ -56,6 +77,11 @@ createInertiaApp({
         ),
     setup({ el, App, props }) {
         const root = createRoot(el);
+
+        trackAnalytics(
+            props.initialPage.props.analytics as
+                AnalyticsPayload | null | undefined,
+        );
 
         root.render(
             <StrictMode>

--- a/resources/js/layouts/auth-layout.tsx
+++ b/resources/js/layouts/auth-layout.tsx
@@ -4,14 +4,21 @@ export default function AuthLayout({
     children,
     title,
     description,
+    homeHref,
     ...props
 }: {
     children: React.ReactNode;
     title: string;
     description: string;
+    homeHref?: string;
 }) {
     return (
-        <AuthLayoutTemplate title={title} description={description} {...props}>
+        <AuthLayoutTemplate
+            title={title}
+            description={description}
+            homeHref={homeHref}
+            {...props}
+        >
             {children}
         </AuthLayoutTemplate>
     );

--- a/resources/js/layouts/auth/auth-simple-layout.tsx
+++ b/resources/js/layouts/auth/auth-simple-layout.tsx
@@ -7,22 +7,33 @@ interface AuthLayoutProps {
     name?: string;
     title?: string;
     description?: string;
+    homeHref?: string;
 }
 
 export default function AuthSimpleLayout({
     children,
     title,
     description,
+    homeHref,
 }: PropsWithChildren<AuthLayoutProps>) {
     return (
         <div className="flex min-h-svh flex-col items-center justify-center bg-[#ECEAE6] p-6 md:p-10 dark:bg-background">
             <div className="flex w-full max-w-md flex-col gap-6">
-                <Link
-                    href={dashboard.url()}
-                    className="flex items-center gap-2 self-center font-medium"
-                >
-                    <AppLogoIcon className="size-9 fill-current text-[var(--foreground)] dark:text-white" />
-                </Link>
+                {homeHref ? (
+                    <a
+                        href={homeHref}
+                        className="flex items-center gap-2 self-center font-medium"
+                    >
+                        <AppLogoIcon className="size-9 fill-current text-[var(--foreground)] dark:text-white" />
+                    </a>
+                ) : (
+                    <Link
+                        href={dashboard.url()}
+                        className="flex items-center gap-2 self-center font-medium"
+                    >
+                        <AppLogoIcon className="size-9 fill-current text-[var(--foreground)] dark:text-white" />
+                    </Link>
+                )}
 
                 <div className="rounded-xl border border-transparent bg-white px-10 py-8 shadow-sm dark:border-border dark:bg-card">
                     <div className="flex flex-col gap-6">

--- a/resources/js/pages/auth/register.tsx
+++ b/resources/js/pages/auth/register.tsx
@@ -46,34 +46,12 @@ export default function Register({
             title={cloudEnabled ? 'Start your free trial' : 'Create an account'}
             description={
                 cloudEnabled
-                    ? '14 days free. No credit card required.'
+                    ? '14 days free. No credit card required. Then $19/month.'
                     : 'Enter your details below to create your account'
             }
             homeHref={cloudEnabled ? 'https://pricore.dev/pricing/' : undefined}
         >
             <Head title="Register" />
-
-            {cloudEnabled && (
-                <div className="rounded-lg border bg-muted/30 px-4 py-3 text-sm">
-                    <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-                        Your plan
-                    </p>
-                    <div className="mt-2 flex items-baseline justify-between gap-3">
-                        <span className="font-semibold">Pricore Cloud</span>
-                        <span className="font-medium">$19/month</span>
-                    </div>
-                    <p className="mt-1 text-muted-foreground">
-                        Unlimited users and packages. Pay after your trial and
-                        cancel anytime.
-                    </p>
-                    <a
-                        href="https://pricore.dev/pricing/"
-                        className="mt-2 inline-block font-medium underline decoration-border underline-offset-4 transition-colors hover:decoration-foreground"
-                    >
-                        See pricing details
-                    </a>
-                </div>
-            )}
 
             {(githubEnabled || gitlabEnabled) && (
                 <>
@@ -209,23 +187,33 @@ export default function Register({
                         </div>
 
                         {cloudEnabled && (
-                            <p className="text-center text-xs leading-relaxed text-muted-foreground">
-                                By creating an account, you agree to our{' '}
-                                <a
-                                    href="https://pricore.dev/terms/"
-                                    className="underline underline-offset-4"
-                                >
-                                    Terms
-                                </a>{' '}
-                                and{' '}
-                                <a
-                                    href="https://pricore.dev/privacy/"
-                                    className="underline underline-offset-4"
-                                >
-                                    Privacy Policy
-                                </a>
-                                .
-                            </p>
+                            <div className="space-y-2 text-center text-xs leading-relaxed text-muted-foreground">
+                                <p>
+                                    <a
+                                        href="https://pricore.dev/pricing/"
+                                        className="underline underline-offset-4"
+                                    >
+                                        View Cloud pricing
+                                    </a>
+                                </p>
+                                <p>
+                                    By creating an account, you agree to our{' '}
+                                    <a
+                                        href="https://pricore.dev/terms/"
+                                        className="underline underline-offset-4"
+                                    >
+                                        Terms
+                                    </a>{' '}
+                                    and{' '}
+                                    <a
+                                        href="https://pricore.dev/privacy/"
+                                        className="underline underline-offset-4"
+                                    >
+                                        Privacy Policy
+                                    </a>
+                                    .
+                                </p>
+                            </div>
                         )}
                     </>
                 )}

--- a/resources/js/pages/auth/register.tsx
+++ b/resources/js/pages/auth/register.tsx
@@ -1,6 +1,7 @@
 import { login } from '@/routes';
 import { store } from '@/routes/register';
-import { Form, Head } from '@inertiajs/react';
+import { Form, Head, usePage } from '@inertiajs/react';
+import { useEffect } from 'react';
 
 import InputError from '@/components/input-error';
 import TextLink from '@/components/text-link';
@@ -10,6 +11,7 @@ import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
 import { Spinner } from '@/components/ui/spinner';
 import AuthLayout from '@/layouts/auth-layout';
+import type { SharedData } from '@/types';
 
 interface RegisterProps {
     githubEnabled?: boolean;
@@ -20,12 +22,54 @@ export default function Register({
     githubEnabled,
     gitlabEnabled,
 }: RegisterProps) {
+    const { cloud } = usePage<SharedData>().props;
+    const cloudEnabled = Boolean(cloud);
+
+    useEffect(() => {
+        const analyticsWindow = window as Window & {
+            gtag?: (...args: unknown[]) => void;
+        };
+
+        analyticsWindow.gtag?.('event', 'signup_view');
+    }, []);
+
+    const trackEvent = (event: string, method?: string) => {
+        const analyticsWindow = window as Window & {
+            gtag?: (...args: unknown[]) => void;
+        };
+
+        analyticsWindow.gtag?.('event', event, method ? { method } : undefined);
+    };
+
     return (
         <AuthLayout
-            title="Create an account"
-            description="Enter your details below to create your account"
+            title={cloudEnabled ? 'Start your free trial' : 'Create an account'}
+            description={
+                cloudEnabled
+                    ? '14 days free. No credit card required.'
+                    : 'Enter your details below to create your account'
+            }
+            homeHref={cloudEnabled ? 'https://pricore.dev/pricing/' : undefined}
         >
             <Head title="Register" />
+
+            {cloudEnabled && (
+                <div className="rounded-lg border border-orange-200 bg-orange-50 px-4 py-3 text-sm dark:border-orange-900/60 dark:bg-orange-950/30">
+                    <div className="flex items-baseline justify-between gap-3">
+                        <span className="font-medium">Pricore Cloud</span>
+                        <span className="font-semibold">$19/month</span>
+                    </div>
+                    <p className="mt-1 text-muted-foreground">
+                        Unlimited users and packages. Cancel anytime.
+                    </p>
+                    <a
+                        href="https://pricore.dev/pricing/"
+                        className="mt-2 inline-block font-medium text-orange-700 underline underline-offset-4 dark:text-orange-400"
+                    >
+                        View pricing details
+                    </a>
+                </div>
+            )}
 
             {(githubEnabled || gitlabEnabled) && (
                 <>
@@ -33,6 +77,9 @@ export default function Register({
                         {githubEnabled && (
                             <a
                                 href="/auth/github/redirect"
+                                onClick={() =>
+                                    trackEvent('signup_method_select', 'github')
+                                }
                                 className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md border bg-background font-medium shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
                             >
                                 <svg
@@ -48,6 +95,9 @@ export default function Register({
                         {gitlabEnabled && (
                             <a
                                 href="/auth/gitlab/redirect"
+                                onClick={() =>
+                                    trackEvent('signup_method_select', 'gitlab')
+                                }
                                 className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md border bg-background font-medium shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
                             >
                                 <svg
@@ -79,6 +129,11 @@ export default function Register({
                 action={store.url()}
                 method="post"
                 resetOnSuccess={['password', 'password_confirmation']}
+                transform={(data) => ({
+                    ...data,
+                    password_confirmation: data.password,
+                })}
+                onSuccess={() => trackEvent('sign_up', 'email')}
                 disableWhileProcessing
                 className="flex flex-col gap-6"
             >
@@ -131,28 +186,10 @@ export default function Register({
                                 <InputError message={errors.password} />
                             </div>
 
-                            <div className="grid gap-2">
-                                <Label htmlFor="password_confirmation">
-                                    Confirm password
-                                </Label>
-                                <Input
-                                    id="password_confirmation"
-                                    type="password"
-                                    required
-                                    tabIndex={4}
-                                    autoComplete="new-password"
-                                    name="password_confirmation"
-                                    placeholder="Confirm password"
-                                />
-                                <InputError
-                                    message={errors.password_confirmation}
-                                />
-                            </div>
-
                             <Button
                                 type="submit"
                                 className="mt-2 h-10 w-full"
-                                tabIndex={5}
+                                tabIndex={4}
                                 data-test="register-user-button"
                             >
                                 {processing && <Spinner />}
@@ -162,10 +199,30 @@ export default function Register({
 
                         <div className="text-center text-muted-foreground">
                             Already have an account?{' '}
-                            <TextLink href={login()} tabIndex={6}>
+                            <TextLink href={login()} tabIndex={5}>
                                 Log in
                             </TextLink>
                         </div>
+
+                        {cloudEnabled && (
+                            <p className="text-center text-xs leading-relaxed text-muted-foreground">
+                                By creating an account, you agree to our{' '}
+                                <a
+                                    href="https://pricore.dev/terms/"
+                                    className="underline underline-offset-4"
+                                >
+                                    Terms
+                                </a>{' '}
+                                and{' '}
+                                <a
+                                    href="https://pricore.dev/privacy/"
+                                    className="underline underline-offset-4"
+                                >
+                                    Privacy Policy
+                                </a>
+                                .
+                            </p>
+                        )}
                     </>
                 )}
             </Form>

--- a/resources/js/pages/auth/register.tsx
+++ b/resources/js/pages/auth/register.tsx
@@ -54,19 +54,23 @@ export default function Register({
             <Head title="Register" />
 
             {cloudEnabled && (
-                <div className="rounded-lg border border-orange-200 bg-orange-50 px-4 py-3 text-sm dark:border-orange-900/60 dark:bg-orange-950/30">
-                    <div className="flex items-baseline justify-between gap-3">
-                        <span className="font-medium">Pricore Cloud</span>
-                        <span className="font-semibold">$19/month</span>
+                <div className="rounded-lg border bg-muted/30 px-4 py-3 text-sm">
+                    <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                        Your plan
+                    </p>
+                    <div className="mt-2 flex items-baseline justify-between gap-3">
+                        <span className="font-semibold">Pricore Cloud</span>
+                        <span className="font-medium">$19/month</span>
                     </div>
                     <p className="mt-1 text-muted-foreground">
-                        Unlimited users and packages. Cancel anytime.
+                        Unlimited users and packages. Pay after your trial and
+                        cancel anytime.
                     </p>
                     <a
                         href="https://pricore.dev/pricing/"
-                        className="mt-2 inline-block font-medium text-orange-700 underline underline-offset-4 dark:text-orange-400"
+                        className="mt-2 inline-block font-medium underline decoration-border underline-offset-4 transition-colors hover:decoration-foreground"
                     >
-                        View pricing details
+                        See pricing details
                     </a>
                 </div>
             )}

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -47,6 +47,18 @@
 
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
 
+    @if ($googleAnalyticsId = config('services.google_analytics.id'))
+        <script async src="https://www.googletagmanager.com/gtag/js?id={{ $googleAnalyticsId }}"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', @json($googleAnalyticsId), {
+                linker: { domains: ['pricore.dev', 'app.pricore.dev'] }
+            });
+        </script>
+    @endif
+
     @if (config('cashier.client_side_token'))
         <script src="https://cdn.paddle.com/paddle/v2/paddle.js"></script>
         @if (config('cashier.sandbox'))

--- a/tests/Feature/Auth/GitHubAuthenticationTest.php
+++ b/tests/Feature/Auth/GitHubAuthenticationTest.php
@@ -78,6 +78,10 @@ test('callback creates new user from GitHub', function () {
         ->get(route('auth.github.callback'));
 
     $response->assertRedirect(route('dashboard'));
+    $response->assertSessionHas('analytics', [
+        'event' => 'sign_up',
+        'method' => 'github',
+    ]);
     $this->assertAuthenticated();
 
     $user = User::where('email', 'john@example.com')->first();

--- a/tests/Feature/Auth/GitLabAuthenticationTest.php
+++ b/tests/Feature/Auth/GitLabAuthenticationTest.php
@@ -78,6 +78,10 @@ test('callback creates new user from GitLab', function () {
         ->get(route('auth.gitlab.callback'));
 
     $response->assertRedirect(route('dashboard'));
+    $response->assertSessionHas('analytics', [
+        'event' => 'sign_up',
+        'method' => 'gitlab',
+    ]);
     $this->assertAuthenticated();
 
     $user = User::where('email', 'jane@example.com')->first();


### PR DESCRIPTION
## Summary

- add hosted-plan context to the registration page while keeping self-hosted registration unchanged
- simplify password entry without changing server-side confirmation validation
- add optional Google Analytics hooks for registration views, methods, and completed signups
- preserve signup attribution for new GitHub and GitLab users

## Configuration

Hosted deployments can set `GOOGLE_ANALYTICS_ID` to enable analytics. Self-hosted installations remain unaffected by default.

## Testing

- `npm run format:check`
- `npm run types`
- `npm run build`
- `php artisan test tests/Feature/Auth/RegistrationTest.php tests/Feature/Auth/GitHubAuthenticationTest.php tests/Feature/Auth/GitLabAuthenticationTest.php`

43 tests passed with 163 assertions.