### PR TITLE
fix: enforce organization ownership of repository SSH keys

### DIFF
--- a/app/Domains/Repository/Actions/CreateGitCloneAction.php
+++ b/app/Domains/Repository/Actions/CreateGitCloneAction.php
@@ -89,6 +89,10 @@ class CreateGitCloneAction
         $sshKey = $repository->sshKey;
 
         if ($sshKey) {
+            if ($sshKey->organization_uuid !== $repository->organization_uuid) {
+                throw new GitProviderException('The SSH key does not belong to the repository organization.');
+            }
+
             $tempKeyFile = sys_get_temp_dir().'/pricore-ssh-'.Str::random(16);
             file_put_contents($tempKeyFile, $sshKey->private_key."\n");
             chmod($tempKeyFile, 0600);

--- a/app/Domains/Repository/Http/Requests/StoreRepositoryRequest.php
+++ b/app/Domains/Repository/Http/Requests/StoreRepositoryRequest.php
@@ -4,6 +4,7 @@ namespace App\Domains\Repository\Http\Requests;
 
 use App\Domains\Repository\Contracts\Enums\GitProvider;
 use App\Domains\Repository\Rules\ValidRepositoryIdentifier;
+use App\Models\Organization;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -15,6 +16,9 @@ class StoreRepositoryRequest extends FormRequest
      */
     public function rules(): array
     {
+        /** @var Organization $organization */
+        $organization = $this->route('organization');
+
         return [
             'name' => ['nullable', 'string', 'max:255'],
             'provider' => ['required', 'string', Rule::enum(GitProvider::class)],
@@ -25,7 +29,12 @@ class StoreRepositoryRequest extends FormRequest
                 new ValidRepositoryIdentifier(GitProvider::tryFrom((string) $this->input('provider'))),
             ],
             'default_branch' => ['nullable', 'string', 'max:255'],
-            'ssh_key_uuid' => ['nullable', 'uuid', Rule::exists('organization_ssh_keys', 'uuid')],
+            'ssh_key_uuid' => [
+                'nullable',
+                'uuid',
+                Rule::exists('organization_ssh_keys', 'uuid')
+                    ->where('organization_uuid', $organization->uuid),
+            ],
         ];
     }
 }

--- a/app/Domains/Repository/Services/GitProviders/GitProviderFactory.php
+++ b/app/Domains/Repository/Services/GitProviders/GitProviderFactory.php
@@ -4,6 +4,7 @@ namespace App\Domains\Repository\Services\GitProviders;
 
 use App\Domains\Repository\Contracts\Enums\GitProvider;
 use App\Domains\Repository\Contracts\Interfaces\GitProviderInterface;
+use App\Domains\Repository\Exceptions\GitProviderException;
 use App\Models\OrganizationSshKey;
 use App\Models\Repository;
 use App\Models\UserGitCredential;
@@ -56,6 +57,10 @@ class GitProviderFactory
 
         if (! $organizationSshKey) {
             return [];
+        }
+
+        if ($organizationSshKey->organization_uuid !== $repository->organization_uuid) {
+            throw new GitProviderException('The SSH key does not belong to the repository organization.');
         }
 
         return ['ssh_key' => $organizationSshKey->private_key];

--- a/tests/Feature/Security/RepositorySshKeyAuthorizationTest.php
+++ b/tests/Feature/Security/RepositorySshKeyAuthorizationTest.php
@@ -1,0 +1,133 @@
+<?php
+
+use App\Domains\Organization\Contracts\Enums\OrganizationRole;
+use App\Domains\Repository\Actions\CreateGitCloneAction;
+use App\Domains\Repository\Exceptions\GitProviderException;
+use App\Domains\Repository\Jobs\SyncRepositoryJob;
+use App\Domains\Repository\Services\GitProviders\GitProviderFactory;
+use App\Models\Organization;
+use App\Models\OrganizationSshKey;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+
+uses()->group('security', 'repositories', 'ssh-keys');
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+    Process::preventStrayProcesses();
+    Queue::fake();
+    $this->user = User::factory()->create();
+    $this->organization = Organization::factory()->create();
+    $this->organization->members()->attach($this->user->uuid, [
+        'uuid' => Str::uuid()->toString(),
+        'role' => OrganizationRole::Admin->value,
+    ]);
+});
+
+it('rejects another organization SSH key without creating or syncing a repository', function () {
+    $foreignKey = OrganizationSshKey::factory()->create();
+
+    $this->actingAs($this->user)
+        ->post(route('organizations.repositories.store', $this->organization), [
+            'provider' => 'git',
+            'repo_identifier' => 'git@git.example.com:private/package.git',
+            'ssh_key_uuid' => $foreignKey->uuid,
+        ])
+        ->assertSessionHasErrors('ssh_key_uuid');
+
+    $this->assertDatabaseCount('repositories', 0);
+    Queue::assertNothingPushed();
+    Process::assertNothingRan();
+    Http::assertNothingSent();
+});
+
+it('allows a repository with its own organization key or no key', function (bool $withKey) {
+    $key = $withKey ? OrganizationSshKey::factory()->create([
+        'organization_uuid' => $this->organization->uuid,
+    ]) : null;
+
+    $this->actingAs($this->user)
+        ->post(route('organizations.repositories.store', $this->organization), [
+            'provider' => 'git',
+            'repo_identifier' => 'git@git.example.com:private/package.git',
+            'ssh_key_uuid' => $key?->uuid,
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect();
+
+    expect($this->organization->repositories()->sole()->ssh_key_uuid)->toBe($key?->uuid);
+    Queue::assertPushed(SyncRepositoryJob::class);
+})->with([true, false]);
+
+it('rejects a stored foreign key before a provider can use it', function () {
+    $key = OrganizationSshKey::factory()->create();
+    $repository = Repository::factory()->create([
+        'organization_uuid' => $this->organization->uuid,
+        'provider' => 'git',
+        'repo_identifier' => 'git@git.example.com:private/package.git',
+        'ssh_key_uuid' => $key->uuid,
+    ]);
+
+    expect(fn () => GitProviderFactory::make($repository))
+        ->toThrow(GitProviderException::class, 'The SSH key does not belong to the repository organization.');
+    Process::assertNothingRan();
+});
+
+it('rejects a stored foreign key before cloning or fetching', function (bool $existingClone) {
+    $key = OrganizationSshKey::factory()->create();
+    $repository = Repository::factory()->create([
+        'organization_uuid' => $this->organization->uuid,
+        'provider' => 'git',
+        'repo_identifier' => 'git@git.example.com:private/package.git',
+        'ssh_key_uuid' => $key->uuid,
+    ]);
+    $clonePath = storage_path("app/git-clones/{$repository->uuid}");
+
+    try {
+        if ($existingClone) {
+            File::ensureDirectoryExists($clonePath);
+        }
+
+        expect(fn () => app(CreateGitCloneAction::class)->handle($repository))
+            ->toThrow(GitProviderException::class, 'The SSH key does not belong to the repository organization.');
+        Process::assertNothingRan();
+    } finally {
+        if ($existingClone) {
+            File::deleteDirectory($clonePath);
+        }
+    }
+})->with([true, false]);
+
+it('uses an authorized key for both provider requests and cloning then removes the temporary key', function () {
+    $key = OrganizationSshKey::factory()->create([
+        'organization_uuid' => $this->organization->uuid,
+        'private_key' => 'test-authorized-private-key',
+    ]);
+    $repository = Repository::factory()->create([
+        'organization_uuid' => $this->organization->uuid,
+        'provider' => 'git',
+        'repo_identifier' => 'git@git.example.com:private/package.git',
+        'ssh_key_uuid' => $key->uuid,
+    ]);
+    $keyPaths = [];
+    Process::fake(function ($process) use (&$keyPaths) {
+        preg_match('/ssh -i (\S+)/', $process->environment['GIT_SSH_COMMAND'], $matches);
+        $keyPaths[] = $matches[1];
+        expect(trim(file_get_contents($matches[1])))->toBe('test-authorized-private-key');
+
+        return Process::result();
+    });
+
+    expect(GitProviderFactory::make($repository)->validateCredentials())->toBeTrue();
+    app(CreateGitCloneAction::class)->handle($repository);
+
+    expect($keyPaths)->toHaveCount(2);
+    foreach ($keyPaths as $keyPath) {
+        expect(file_exists($keyPath))->toBeFalse();
+    }
+});


### PR DESCRIPTION
Repository creation accepted any existing SSH key UUID, allowing an organization administrator to attach a key owned by another organization. Restrict validation to the repository organization and reject mismatched stored associations when loading credentials for Git provider requests, clones, and fetches.

Existing invalid associations now fail before Git uses the key. Keys belonging to the current organization and repositories without an SSH key retain their existing behavior. No data migration is included.

Seven regression tests cover request rejection without persistence or sync dispatch, stored invalid associations, clone/fetch guards, authorized keys, repositories without keys, and temporary-key cleanup.

Validation:
- 84 relevant repository, authorization, and SSH tests passed (291 assertions).
- PHPStan passed for the three changed application files.
- Pint passed for all four changed files, including the commit hook.
- `git diff --check` passed.
