### PR TITLE
fix: respect two-factor authentication during OAuth login

### DIFF
--- a/app/Domains/Auth/Actions/AuthenticateOAuthUserAction.php
+++ b/app/Domains/Auth/Actions/AuthenticateOAuthUserAction.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Domains\Auth\Actions;
+
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+use Laravel\Fortify\Events\TwoFactorAuthenticationChallenged;
+use Laravel\Fortify\Features;
+
+class AuthenticateOAuthUserAction
+{
+    public function handle(User $user): RedirectResponse
+    {
+        if (Features::enabled(Features::twoFactorAuthentication()) && $user->hasEnabledTwoFactorAuthentication()) {
+            // The existing Fortify challenge requires a guest session.
+            Auth::logout();
+            session()->regenerate();
+            session()->put([
+                'login.id' => $user->getKey(),
+                'login.remember' => true,
+            ]);
+
+            TwoFactorAuthenticationChallenged::dispatch($user);
+
+            return redirect()->route('two-factor.login');
+        }
+
+        Auth::login($user, remember: true);
+
+        return redirect()->intended(route('dashboard'));
+    }
+}

--- a/app/Http/Controllers/Auth/GitHubAuthController.php
+++ b/app/Http/Controllers/Auth/GitHubAuthController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Auth;
 
+use App\Domains\Auth\Actions\AuthenticateOAuthUserAction;
 use App\Domains\Auth\Actions\FindOrCreateGitHubUserAction;
 use App\Domains\Auth\Actions\SyncUserGitHubCredentialAction;
 use App\Domains\Auth\Actions\UpdateUserGitHubProfileAction;
@@ -34,6 +35,7 @@ class GitHubAuthController extends Controller
         FindOrCreateGitHubUserAction $findOrCreateUser,
         UpdateUserGitHubProfileAction $updateProfile,
         SyncUserGitHubCredentialAction $syncCredential,
+        AuthenticateOAuthUserAction $authenticateUser,
     ): RedirectResponse {
         $intent = session()->pull('github_oauth_intent', GitHubOAuthIntent::Login);
 
@@ -53,11 +55,14 @@ class GitHubAuthController extends Controller
             return $this->handleConnect($githubUser, $updateProfile, $syncCredential);
         }
 
-        return $this->handleLogin($githubUser, $findOrCreateUser);
+        return $this->handleLogin($githubUser, $findOrCreateUser, $authenticateUser);
     }
 
-    private function handleLogin(SocialiteUser $githubUser, FindOrCreateGitHubUserAction $findOrCreateUser): RedirectResponse
-    {
+    private function handleLogin(
+        SocialiteUser $githubUser,
+        FindOrCreateGitHubUserAction $findOrCreateUser,
+        AuthenticateOAuthUserAction $authenticateUser,
+    ): RedirectResponse {
         if (empty($githubUser->getEmail())) {
             return redirect()->route('login')->with('error', 'We could not retrieve your email address from GitHub. Please ensure your email is public or try another sign-in method.');
         }
@@ -74,9 +79,7 @@ class GitHubAuthController extends Controller
         /** @var TwoUser $githubUser */
         $user = $findOrCreateUser->handle($githubUser, $githubUser->token);
 
-        Auth::login($user, remember: true);
-
-        $response = redirect()->intended(route('dashboard'));
+        $response = $authenticateUser->handle($user);
 
         if (! $existingUser) {
             $response->with('analytics', ['event' => 'sign_up', 'method' => 'github']);

--- a/app/Http/Controllers/Auth/GitLabAuthController.php
+++ b/app/Http/Controllers/Auth/GitLabAuthController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Auth;
 
+use App\Domains\Auth\Actions\AuthenticateOAuthUserAction;
 use App\Domains\Auth\Actions\FindOrCreateGitLabUserAction;
 use App\Domains\Auth\Actions\SyncUserGitLabCredentialAction;
 use App\Domains\Auth\Actions\UpdateUserGitLabProfileAction;
@@ -34,6 +35,7 @@ class GitLabAuthController extends Controller
         FindOrCreateGitLabUserAction $findOrCreateUser,
         UpdateUserGitLabProfileAction $updateProfile,
         SyncUserGitLabCredentialAction $syncCredential,
+        AuthenticateOAuthUserAction $authenticateUser,
     ): RedirectResponse {
         $intent = session()->pull('gitlab_oauth_intent', GitLabOAuthIntent::Login);
 
@@ -53,11 +55,14 @@ class GitLabAuthController extends Controller
             return $this->handleConnect($gitlabUser, $updateProfile, $syncCredential);
         }
 
-        return $this->handleLogin($gitlabUser, $findOrCreateUser);
+        return $this->handleLogin($gitlabUser, $findOrCreateUser, $authenticateUser);
     }
 
-    private function handleLogin(SocialiteUser $gitlabUser, FindOrCreateGitLabUserAction $findOrCreateUser): RedirectResponse
-    {
+    private function handleLogin(
+        SocialiteUser $gitlabUser,
+        FindOrCreateGitLabUserAction $findOrCreateUser,
+        AuthenticateOAuthUserAction $authenticateUser,
+    ): RedirectResponse {
         if (empty($gitlabUser->getEmail())) {
             return redirect()->route('login')->with('error', 'We could not retrieve your email address from GitLab. Please ensure your email is public or try another sign-in method.');
         }
@@ -74,9 +79,7 @@ class GitLabAuthController extends Controller
         /** @var TwoUser $gitlabUser */
         $user = $findOrCreateUser->handle($gitlabUser, $gitlabUser->token);
 
-        Auth::login($user, remember: true);
-
-        $response = redirect()->intended(route('dashboard'));
+        $response = $authenticateUser->handle($user);
 
         if (! $existingUser) {
             $response->with('analytics', ['event' => 'sign_up', 'method' => 'gitlab']);

--- a/tests/Feature/Auth/GitHubAuthenticationTest.php
+++ b/tests/Feature/Auth/GitHubAuthenticationTest.php
@@ -94,7 +94,7 @@ test('callback creates new user from GitHub', function () {
 });
 
 test('callback logs in existing user matched by github_id', function () {
-    $user = User::factory()->withGitHub()->create([
+    $user = User::factory()->withoutTwoFactor()->withGitHub()->create([
         'github_id' => '12345678',
     ]);
 
@@ -111,7 +111,7 @@ test('callback logs in existing user matched by github_id', function () {
 });
 
 test('callback links GitHub account to existing user matched by email', function () {
-    $user = User::factory()->create(['email' => 'john@example.com']);
+    $user = User::factory()->withoutTwoFactor()->create(['email' => 'john@example.com']);
 
     expect($user->github_id)->toBeNull();
 
@@ -274,7 +274,7 @@ test('callback allows new GitHub user with invitation token when sign up is disa
 test('callback allows existing GitHub user login when sign up is disabled', function () {
     config()->set('fortify.sign_up_enabled', false);
 
-    $user = User::factory()->withGitHub()->create([
+    $user = User::factory()->withoutTwoFactor()->withGitHub()->create([
         'github_id' => '12345678',
     ]);
 
@@ -383,7 +383,7 @@ test('connect callback without auth redirects to login', function () {
 });
 
 test('callback without connect session performs normal login', function () {
-    $user = User::factory()->withGitHub()->create();
+    $user = User::factory()->withoutTwoFactor()->withGitHub()->create();
 
     $socialiteUser = mockSocialiteUser(['id' => $user->github_id]);
     mockSocialiteCallback($socialiteUser);

--- a/tests/Feature/Auth/GitLabAuthenticationTest.php
+++ b/tests/Feature/Auth/GitLabAuthenticationTest.php
@@ -94,7 +94,7 @@ test('callback creates new user from GitLab', function () {
 });
 
 test('callback logs in existing user matched by gitlab_id', function () {
-    $user = User::factory()->withGitLab()->create([
+    $user = User::factory()->withoutTwoFactor()->withGitLab()->create([
         'gitlab_id' => '87654321',
     ]);
 
@@ -111,7 +111,7 @@ test('callback logs in existing user matched by gitlab_id', function () {
 });
 
 test('callback links GitLab account to existing user matched by email', function () {
-    $user = User::factory()->create(['email' => 'jane@example.com']);
+    $user = User::factory()->withoutTwoFactor()->create(['email' => 'jane@example.com']);
 
     expect($user->gitlab_id)->toBeNull();
 

--- a/tests/Feature/Auth/OAuthTwoFactorAuthenticationTest.php
+++ b/tests/Feature/Auth/OAuthTwoFactorAuthenticationTest.php
@@ -1,0 +1,135 @@
+<?php
+
+use App\Models\OrganizationInvitation;
+use App\Models\User;
+use Illuminate\Auth\Events\Login;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Notification;
+use Laravel\Fortify\Events\TwoFactorAuthenticationChallenged;
+use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\User as SocialiteUser;
+use PragmaRX\Google2FA\Google2FA;
+
+uses()->group('auth', 'security');
+
+beforeEach(function () {
+    $this->withoutVite();
+    config(['inertia.ssr.enabled' => false]);
+    Http::preventStrayRequests();
+    Notification::fake();
+    $this->secret = 'JBSWY3DPEHPK3PXP';
+    $this->user = User::factory()->create([
+        'two_factor_secret' => encrypt($this->secret),
+        'two_factor_recovery_codes' => encrypt(json_encode(['test-recovery-code'])),
+        'two_factor_confirmed_at' => now(),
+    ]);
+});
+
+function mockTwoFactorOAuthCallback(User $user, string $provider): void
+{
+    $oauthUser = (new SocialiteUser)->map([
+        'id' => 'two-factor-provider-id',
+        'email' => $user->email,
+        'name' => $user->name,
+        'nickname' => 'two-factor-user',
+        'avatar' => null,
+    ])->setToken('test-oauth-token');
+    $driver = Mockery::mock();
+    $driver->shouldReceive('user')->once()->andReturn($oauthUser);
+    Socialite::shouldReceive('driver')->with($provider)->andReturn($driver);
+}
+
+it('challenges OAuth users with enabled two factor before logging them in', function (string $provider, bool $linked) {
+    if ($linked) {
+        $this->user->update([$provider.'_id' => 'two-factor-provider-id']);
+    }
+    mockTwoFactorOAuthCallback($this->user, $provider);
+    Event::fake([Login::class, TwoFactorAuthenticationChallenged::class]);
+
+    $this->withSession(['url.intended' => route('settings.tokens.index')])
+        ->get(route('auth.'.$provider.'.callback'))
+        ->assertRedirect(route('two-factor.login'))
+        ->assertSessionHas('login.id', $this->user->uuid)
+        ->assertSessionHas('login.remember', true)
+        ->assertSessionHas('url.intended', route('settings.tokens.index'));
+
+    $this->assertGuest();
+    Event::assertNotDispatched(Login::class);
+    Event::assertDispatched(TwoFactorAuthenticationChallenged::class);
+    $this->get(route('two-factor.login'))->assertOk();
+    $this->get(route('dashboard'))->assertRedirect(route('login'));
+})->with(['github', 'gitlab'])->with([false, true]);
+
+it('completes OAuth login through the existing code and recovery challenge', function (string $provider, string $method) {
+    mockTwoFactorOAuthCallback($this->user, $provider);
+    $invitation = OrganizationInvitation::factory()->create(['email' => $this->user->email]);
+    $this->withSession([
+        'url.intended' => route('settings.tokens.index'),
+        'invitation_token' => $invitation->token,
+    ])->get(route('auth.'.$provider.'.callback'))->assertRedirect(route('two-factor.login'));
+
+    $this->assertGuest();
+    expect($invitation->refresh()->accepted_at)->toBeNull();
+
+    $payload = $method === 'code'
+        ? ['code' => app(Google2FA::class)->getCurrentOtp($this->secret)]
+        : ['recovery_code' => 'test-recovery-code'];
+
+    $this->post(route('two-factor.login.store'), $payload)
+        ->assertRedirect(route('settings.tokens.index'))
+        ->assertSessionMissing('login.id')
+        ->assertSessionMissing('login.remember')
+        ->assertCookie(Auth::guard()->getRecallerName());
+
+    $this->assertAuthenticatedAs($this->user);
+    expect($invitation->refresh()->accepted_at)->not->toBeNull();
+    if ($method === 'recovery_code') {
+        expect($this->user->refresh()->recoveryCodes())->not->toContain('test-recovery-code');
+    }
+})->with(['github', 'gitlab'])->with(['code', 'recovery_code']);
+
+it('keeps OAuth users unauthenticated when the second factor is invalid', function (string $provider, string $method) {
+    mockTwoFactorOAuthCallback($this->user, $provider);
+    $this->get(route('auth.'.$provider.'.callback'))->assertRedirect(route('two-factor.login'));
+
+    $this->post(route('two-factor.login.store'), [$method => 'invalid-code'])
+        ->assertRedirect(route('two-factor.login'))
+        ->assertSessionHasErrors($method)
+        ->assertSessionHas('login.id', $this->user->uuid);
+
+    $this->assertGuest();
+})->with(['github', 'gitlab'])->with(['code', 'recovery_code']);
+
+it('allows normal OAuth login when two factor is absent or not yet confirmed', function (string $provider, bool $hasSecret) {
+    $this->user->update([
+        'two_factor_secret' => $hasSecret ? encrypt($this->secret) : null,
+        'two_factor_confirmed_at' => null,
+    ]);
+    mockTwoFactorOAuthCallback($this->user, $provider);
+
+    $this->get(route('auth.'.$provider.'.callback'))->assertRedirect(route('dashboard'));
+    $this->assertAuthenticatedAs($this->user);
+})->with(['github', 'gitlab'])->with([false, true]);
+
+it('honors two factor configuration without a confirmation step', function (string $provider) {
+    config(['fortify-options.two-factor-authentication.confirm' => false]);
+    $this->user->update(['two_factor_confirmed_at' => null]);
+    mockTwoFactorOAuthCallback($this->user, $provider);
+
+    $this->get(route('auth.'.$provider.'.callback'))->assertRedirect(route('two-factor.login'));
+    $this->assertGuest();
+})->with(['github', 'gitlab']);
+
+it('makes the challenge accessible when an OAuth login callback arrives with an existing session', function (string $provider) {
+    mockTwoFactorOAuthCallback($this->user, $provider);
+
+    $this->actingAs(User::factory()->create())
+        ->get(route('auth.'.$provider.'.callback'))
+        ->assertRedirect(route('two-factor.login'))
+        ->assertSessionHas('login.id', $this->user->uuid);
+
+    $this->assertGuest();
+    $this->get(route('two-factor.login'))->assertOk();
+})->with(['github', 'gitlab']);


### PR DESCRIPTION
Use the existing two-factor challenge for GitHub and GitLab logins when enabled. Add coverage for authenticator and recovery codes, and update normal-login test fixtures. Validation: 110 tests passed; Pint and PHPStan passed.