### PR TITLE
feat(repository): sync packages from configured monorepo paths

### DIFF
--- a/app/Domains/Composer/Contracts/Data/VersionMetadataData.php
+++ b/app/Domains/Composer/Contracts/Data/VersionMetadataData.php
@@ -27,7 +27,9 @@ class VersionMetadataData extends Data
             version: $version->version,
             versionNormalized: $version->normalized_version,
             composerJson: $version->composer_json,
-            source: $version->source_url && $version->source_reference ? new SourceData(
+            // A subdirectory package cannot be installed from source: Composer would
+            // check out the whole repository and read its root composer.json.
+            source: $version->source_url && $version->source_reference && $version->source_path === null ? new SourceData(
                 type: 'git',
                 url: $version->source_url,
                 reference: $version->source_reference,

--- a/app/Domains/Package/Contracts/Data/PackageVersionDetailData.php
+++ b/app/Domains/Package/Contracts/Data/PackageVersionDetailData.php
@@ -128,8 +128,8 @@ class PackageVersionDetailData extends Data
         $ref = $version->source_reference ?: $version->source_tag;
 
         if ($provider !== null && $repoIdentifier !== null && $ref !== null && $ref !== '') {
-            $blobBaseUrl = $provider->blobBaseUrl($repoIdentifier, $ref, $customBaseUrl);
-            $rawFileBaseUrl = $provider->rawFileBaseUrl($repoIdentifier, $ref, $customBaseUrl);
+            $blobBaseUrl = $provider->blobBaseUrl($repoIdentifier, $ref, $customBaseUrl, $version->source_path);
+            $rawFileBaseUrl = $provider->rawFileBaseUrl($repoIdentifier, $ref, $customBaseUrl, $version->source_path);
         }
 
         return App::make(MarkdownRenderer::class)->render(

--- a/app/Domains/Repository/Actions/FetchReadmeAction.php
+++ b/app/Domains/Repository/Actions/FetchReadmeAction.php
@@ -8,54 +8,80 @@ use Throwable;
 
 class FetchReadmeAction
 {
+    /**
+     * In order of preference, compared case-insensitively against the directory listing.
+     */
     protected const CANDIDATE_FILENAMES = [
         'README.md',
-        'readme.md',
-        'Readme.md',
         'README.markdown',
-        'readme.markdown',
         'README',
-        'readme',
     ];
 
     protected const MAX_BYTES = 512 * 1024;
 
-    public function handle(GitProviderInterface $provider, string $ref): ?string
+    public function handle(GitProviderInterface $provider, string $ref, string $path = ''): ?string
     {
-        foreach (self::CANDIDATE_FILENAMES as $filename) {
-            try {
-                $contents = $provider->getFileContent($ref, $filename);
-            } catch (Throwable $e) {
-                // A failing provider call (rate-limit, 5xx, auth blip) should not
-                // abort the surrounding sync — the README is non-essential. Bail
-                // the probe loop too: remaining candidates would hit the same
-                // failure and just waste API budget.
-                Log::warning('Failed to fetch README candidate', [
-                    'repository' => $provider->getRepositoryIdentifier(),
-                    'ref' => $ref,
-                    'filename' => $filename,
-                    'error' => $e->getMessage(),
-                ]);
+        $path = trim($path, '/');
 
+        try {
+            $filename = $this->findReadmeFilename($provider, $ref, $path);
+
+            if ($filename === null) {
                 return null;
             }
 
-            if ($contents === null) {
-                continue;
+            $contents = $provider->getFileContent($ref, $path === '' ? $filename : "{$path}/{$filename}");
+        } catch (Throwable $e) {
+            // A failing provider call (rate-limit, 5xx, auth blip) should not
+            // abort the surrounding sync — the README is non-essential.
+            Log::warning('Failed to fetch README', [
+                'repository' => $provider->getRepositoryIdentifier(),
+                'ref' => $ref,
+                'path' => $path,
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+
+        if ($contents === null) {
+            return null;
+        }
+
+        if (strlen($contents) > self::MAX_BYTES) {
+            Log::info('Skipped README that exceeds the size cap', [
+                'repository' => $provider->getRepositoryIdentifier(),
+                'ref' => $ref,
+                'path' => $path,
+                'size_bytes' => strlen($contents),
+            ]);
+
+            return null;
+        }
+
+        return $contents;
+    }
+
+    /**
+     * One directory listing replaces probing every candidate filename, which
+     * matters once a monorepo multiplies the lookups per ref.
+     */
+    protected function findReadmeFilename(GitProviderInterface $provider, string $ref, string $path): ?string
+    {
+        $files = [];
+
+        foreach ($provider->listDirectory($ref, $path) as $entry) {
+            if ($entry['type'] === 'file') {
+                $files[strtolower($entry['name'])] ??= $entry['name'];
             }
+        }
 
-            if (strlen($contents) > self::MAX_BYTES) {
-                Log::info('Skipped README that exceeds the size cap', [
-                    'repository' => $provider->getRepositoryIdentifier(),
-                    'ref' => $ref,
-                    'filename' => $filename,
-                    'size_bytes' => strlen($contents),
-                ]);
+        foreach (self::CANDIDATE_FILENAMES as $candidate) {
+            $name = $files[strtolower($candidate)] ?? null;
 
-                return null;
+            if ($name !== null) {
+                return $name;
             }
-
-            return $contents;
         }
 
         return null;

--- a/app/Domains/Repository/Actions/FilterChangedRefsAction.php
+++ b/app/Domains/Repository/Actions/FilterChangedRefsAction.php
@@ -42,9 +42,10 @@ class FilterChangedRefsAction
     }
 
     /**
-     * Build a keyed collection of existing package versions for fast lookup.
+     * Existing package versions grouped by version string. A monorepo yields one
+     * row per package for the same tag, so the lookup keeps all of them.
      *
-     * @return Collection<string, ExistingVersionData>
+     * @return Collection<string, Collection<int, ExistingVersionData>>
      */
     protected function getExistingVersionLookup(Repository $repository): Collection
     {
@@ -62,19 +63,27 @@ class FilterChangedRefsAction
                 version: $pv->version,
                 sourceReference: (string) $pv->source_reference,
             ))
-            ->keyBy('version');
+            ->groupBy('version');
     }
 
     /**
-     * Determine if a ref has changed compared to existing versions.
+     * A ref is unchanged only when every package synced from it already sits at
+     * its commit. A single stale row (a package that failed last time, or was
+     * configured later) keeps the ref in the sync.
      *
-     * @param  Collection<string, ExistingVersionData>  $existingVersions
+     * @param  Collection<string, Collection<int, ExistingVersionData>>  $existingVersions
      */
     protected function hasChanged(RefData $ref, Collection $existingVersions): bool
     {
         $version = ComposerMetadataData::extractVersion($ref->name);
         $existing = $existingVersions->get($version);
 
-        return ! $existing || ! $existing->matches($version, $ref->commit);
+        if ($existing === null || $existing->isEmpty()) {
+            return true;
+        }
+
+        return $existing->contains(
+            fn (ExistingVersionData $existingVersion) => ! $existingVersion->matches($version, $ref->commit)
+        );
     }
 }

--- a/app/Domains/Repository/Actions/FindOrCreatePackageAction.php
+++ b/app/Domains/Repository/Actions/FindOrCreatePackageAction.php
@@ -2,24 +2,91 @@
 
 namespace App\Domains\Repository\Actions;
 
+use App\Domains\Activity\Actions\RecordActivityTask;
+use App\Domains\Activity\Contracts\Enums\ActivityType;
 use App\Models\Package;
 use App\Models\Repository;
+use Illuminate\Support\Facades\Log;
 
 class FindOrCreatePackageAction
 {
+    public function __construct(
+        protected RecordActivityTask $recordActivityTask,
+    ) {}
+
     /**
-     * Find or create a package.
+     * Returns null when the name already belongs to a package of another
+     * repository or a mirror: attaching this repository's versions to it would
+     * silently mix two sources under one name.
      */
-    public function handle(Repository $repository, string $packageName): Package
+    public function handle(Repository $repository, string $packageName, string $sourcePath = ''): ?Package
     {
-        return Package::query()
-            ->firstOrCreate([
-                'organization_uuid' => $repository->organization_uuid,
-                'name' => $packageName,
-            ], [
-                'repository_uuid' => $repository->uuid,
-                'type' => 'library',
-                'visibility' => 'private',
+        $sourcePath = $sourcePath === '' ? null : $sourcePath;
+
+        $package = Package::query()->firstOrCreate([
+            'organization_uuid' => $repository->organization_uuid,
+            'name' => $packageName,
+        ], [
+            'repository_uuid' => $repository->uuid,
+            'source_path' => $sourcePath,
+            'type' => 'library',
+            'visibility' => 'private',
+        ]);
+
+        if ($package->wasRecentlyCreated) {
+            $this->recordCreated($repository, $package);
+
+            return $package;
+        }
+
+        $ownedElsewhere = $package->mirror_uuid !== null
+            || ($package->repository_uuid !== null && $package->repository_uuid !== $repository->uuid);
+
+        if ($ownedElsewhere) {
+            Log::warning('Package name is already used by another source', [
+                'repository' => $repository->name,
+                'package' => $packageName,
+                'owner_repository_uuid' => $package->repository_uuid,
+                'owner_mirror_uuid' => $package->mirror_uuid,
             ]);
+
+            return null;
+        }
+
+        $changes = [];
+
+        if ($package->repository_uuid === null) {
+            $changes['repository_uuid'] = $repository->uuid;
+        }
+
+        if ($package->source_path !== $sourcePath) {
+            $changes['source_path'] = $sourcePath;
+        }
+
+        if ($changes !== []) {
+            $package->update($changes);
+        }
+
+        return $package;
+    }
+
+    protected function recordCreated(Repository $repository, Package $package): void
+    {
+        $organization = $repository->organization()->first();
+
+        if (! $organization) {
+            return;
+        }
+
+        $this->recordActivityTask->handle(
+            organization: $organization,
+            type: ActivityType::PackageCreated,
+            subject: $package,
+            properties: [
+                'name' => $package->name,
+                'repository_name' => $repository->name,
+                'source_path' => $package->source_path,
+            ],
+        );
     }
 }

--- a/app/Domains/Repository/Actions/ResolvePackagePathsAction.php
+++ b/app/Domains/Repository/Actions/ResolvePackagePathsAction.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Domains\Repository\Actions;
+
+use App\Domains\Repository\Contracts\Interfaces\GitProviderInterface;
+use App\Domains\Repository\Services\PackagePaths\PackagePathPattern;
+use App\Models\Repository;
+use Illuminate\Support\Facades\Log;
+
+class ResolvePackagePathsAction
+{
+    /**
+     * Directories holding a composer.json to sync at $ref, relative to the
+     * repository root ('' for the root itself). Without configured paths the
+     * repository is the classic single package at the root; with them, the
+     * root takes part only when listed explicitly as ".".
+     *
+     * @return array<int, string>
+     */
+    public function handle(GitProviderInterface $provider, Repository $repository, string $ref): array
+    {
+        $patterns = $repository->package_paths ?? [];
+
+        if ($patterns === []) {
+            return [''];
+        }
+
+        $paths = [];
+
+        foreach ($patterns as $pattern) {
+            $pattern = PackagePathPattern::normalize((string) $pattern);
+
+            if (! PackagePathPattern::isValid($pattern)) {
+                Log::warning('Ignoring invalid package path pattern', [
+                    'repository' => $repository->name,
+                    'pattern' => $pattern,
+                ]);
+
+                continue;
+            }
+
+            if ($pattern === PackagePathPattern::ROOT) {
+                $paths[] = '';
+
+                continue;
+            }
+
+            if (! PackagePathPattern::isWildcard($pattern)) {
+                $paths[] = $pattern;
+
+                continue;
+            }
+
+            $parent = PackagePathPattern::wildcardParent($pattern);
+
+            foreach ($provider->listDirectory($ref, $parent) as $entry) {
+                if ($entry['type'] !== 'dir' || str_starts_with($entry['name'], '.') || ! PackagePathPattern::isValidSegment($entry['name'])) {
+                    continue;
+                }
+
+                $paths[] = $parent === '' ? $entry['name'] : "{$parent}/{$entry['name']}";
+            }
+        }
+
+        $paths = array_values(array_unique($paths));
+        sort($paths);
+
+        return $paths;
+    }
+}

--- a/app/Domains/Repository/Actions/SyncRefAction.php
+++ b/app/Domains/Repository/Actions/SyncRefAction.php
@@ -4,7 +4,9 @@ namespace App\Domains\Repository\Actions;
 
 use App\Domains\Repository\Contracts\Data\ComposerMetadataData;
 use App\Domains\Repository\Contracts\Data\RefData;
+use App\Domains\Repository\Contracts\Data\SyncRefResultData;
 use App\Domains\Repository\Contracts\Interfaces\GitProviderInterface;
+use App\Exceptions\ComposerMetadataException;
 use App\Models\Package;
 use App\Models\PackageVersion;
 use App\Models\Repository;
@@ -14,61 +16,118 @@ use Illuminate\Support\Facades\Log;
 class SyncRefAction
 {
     public function __construct(
-        protected FindOrCreatePackageAction $findOrCreatePackage,
-        protected CreateDistArchiveAction $createDistArchive,
+        protected ResolvePackagePathsAction $resolvePackagePathsAction,
+        protected FindOrCreatePackageAction $findOrCreatePackageAction,
         protected FetchReadmeAction $fetchReadmeAction,
+        protected CreateDistArchiveAction $createDistArchiveAction,
         protected RecordDistArchiveAction $recordDistArchiveAction,
         protected DetachDistArchivesTask $detachDistArchivesTask,
     ) {}
 
     /**
-     * Sync a single ref (tag or branch).
-     *
-     * @return string added|updated|skipped
+     * Sync every package present at a ref (tag or branch), then drop the ref's
+     * version from packages of this repository that are no longer found at it.
      */
-    public function handle(
+    public function handle(GitProviderInterface $provider, Repository $repository, RefData $ref): SyncRefResultData
+    {
+        $result = new SyncRefResultData;
+        $syncedPackageUuids = [];
+        $unreadablePaths = [];
+        $pathsByName = [];
+
+        foreach ($this->resolvePackagePathsAction->handle($provider, $repository, $ref->name) as $path) {
+            $composerJson = $provider->getFileContent($ref->name, self::join($path, 'composer.json'));
+
+            if ($composerJson === null) {
+                $result->skipped++;
+
+                continue;
+            }
+
+            try {
+                $metadata = ComposerMetadataData::fromComposerJson($composerJson, $ref->name);
+            } catch (ComposerMetadataException $e) {
+                Log::warning('Skipping package with invalid composer.json', [
+                    'repository' => $repository->name,
+                    'ref' => $ref->name,
+                    'path' => $path,
+                    'error' => $e->getMessage(),
+                ]);
+
+                $unreadablePaths[] = $path;
+                $result->skipped++;
+
+                continue;
+            }
+
+            if (isset($pathsByName[$metadata->name])) {
+                Log::warning('Skipping duplicate package name within ref', [
+                    'repository' => $repository->name,
+                    'ref' => $ref->name,
+                    'package' => $metadata->name,
+                    'path' => $path,
+                    'first_path' => $pathsByName[$metadata->name],
+                ]);
+
+                $result->skipped++;
+
+                continue;
+            }
+
+            $pathsByName[$metadata->name] = $path;
+
+            $package = $this->findOrCreatePackageAction->handle($repository, $metadata->name, $path);
+
+            if ($package === null) {
+                $result->skipped++;
+
+                continue;
+            }
+
+            $syncedPackageUuids[] = $package->uuid;
+
+            match ($this->syncVersion($provider, $repository, $ref, $package, $metadata, $path)) {
+                'added' => $result->added++,
+                'updated' => $result->updated++,
+                default => $result->skipped++,
+            };
+        }
+
+        $result->packagesFound = count($syncedPackageUuids);
+        $result->removed = $this->removeVanishedVersions($repository, $ref, $syncedPackageUuids, $unreadablePaths);
+
+        return $result;
+    }
+
+    /**
+     * @return 'added'|'updated'|'skipped'
+     */
+    protected function syncVersion(
         GitProviderInterface $provider,
         Repository $repository,
-        RefData $ref
+        RefData $ref,
+        Package $package,
+        ComposerMetadataData $metadata,
+        string $path,
     ): string {
-        // First, get composer.json to extract package name
-        $composerJson = $provider->getFileContent($ref->name, 'composer.json');
+        $sourcePath = $path === '' ? null : $path;
 
-        if (! $composerJson) {
+        $existingVersion = PackageVersion::query()
+            ->where('package_uuid', $package->uuid)
+            ->where('version', $metadata->version)
+            ->first();
+
+        // Same commit at the same location: nothing changed, skip the expensive work
+        if ($existingVersion
+            && $existingVersion->source_reference === $ref->commit
+            && $existingVersion->source_path === $sourcePath) {
             return 'skipped';
         }
 
-        $metadata = ComposerMetadataData::fromComposerJson($composerJson, $ref->name);
+        $readme = $this->fetchReadmeAction->handle($provider, $ref->name, $path);
+        $sourceUrl = $provider->getRepositoryUrl();
 
-        // Check if this version already exists with the same commit SHA
-        // If so, skip the expensive sync operation
-        $package = Package::query()
-            ->where('organization_uuid', $repository->organization_uuid)
-            ->where('name', $metadata->name)
-            ->first();
-
-        if ($package) {
-            $existingVersion = PackageVersion::query()
-                ->where('package_uuid', $package->uuid)
-                ->where('version', $metadata->version)
-                ->where('source_reference', $ref->commit)
-                ->first();
-
-            if ($existingVersion) {
-                // Version exists with the same commit SHA - no changes needed
-                return 'skipped';
-            }
-        }
-
-        $readme = $this->fetchReadmeAction->handle($provider, $ref->name);
-
-        $result = DB::transaction(function () use ($metadata, $ref, $package, $repository, $provider, $readme): array {
-            if (! $package) {
-                $package = $this->findOrCreatePackage->handle($repository, $metadata->name);
-            }
-
-            $sourceUrl = $provider->getRepositoryUrl();
-
+        $result = DB::transaction(function () use ($metadata, $ref, $package, $sourceUrl, $sourcePath, $readme): array {
             $version = PackageVersion::query()
                 ->where('package_uuid', $package->uuid)
                 ->where('version', $metadata->version)
@@ -80,7 +139,6 @@ class SyncRefAction
                 // would serve the previous archive under the new reference.
                 $this->detachDistArchivesTask->handle($version);
 
-                // Version exists but commit SHA changed - update it
                 $version->update([
                     'normalized_version' => $metadata->normalizedVersion,
                     'composer_json' => $metadata->composerJson,
@@ -88,9 +146,10 @@ class SyncRefAction
                     'source_url' => $sourceUrl,
                     'source_reference' => $ref->commit,
                     'source_tag' => $ref->name,
+                    'source_path' => $sourcePath,
                 ]);
 
-                return ['status' => 'updated', 'version' => $version, 'package' => $package];
+                return ['status' => 'updated', 'version' => $version];
             }
 
             $version = PackageVersion::create([
@@ -102,14 +161,15 @@ class SyncRefAction
                 'source_url' => $sourceUrl,
                 'source_reference' => $ref->commit,
                 'source_tag' => $ref->name,
+                'source_path' => $sourcePath,
                 'released_at' => now(),
             ]);
 
-            return ['status' => 'added', 'version' => $version, 'package' => $package];
+            return ['status' => 'added', 'version' => $version];
         });
 
         if (config('pricore.dist.enabled')) {
-            $this->createDistForVersion($provider, $result['version'], $result['package'], $repository);
+            $this->createDistForVersion($provider, $result['version'], $package, $repository);
         }
 
         return $result['status'];
@@ -124,7 +184,7 @@ class SyncRefAction
         try {
             $organizationSlug = $repository->organization->slug;
 
-            $dist = $this->createDistArchive->handle($provider, $version, $organizationSlug);
+            $dist = $this->createDistArchiveAction->handle($provider, $version, $organizationSlug);
 
             if (! $dist) {
                 return;
@@ -138,5 +198,48 @@ class SyncRefAction
                 'error' => $e->getMessage(),
             ]);
         }
+    }
+
+    /**
+     * A package without a composer.json at this ref (directory removed, package
+     * renamed) must stop advertising the ref's version. Paths whose composer.json
+     * could not be parsed are left alone: that package is still there, just broken.
+     *
+     * @param  array<int, string>  $syncedPackageUuids
+     * @param  array<int, string>  $unreadablePaths
+     */
+    protected function removeVanishedVersions(
+        Repository $repository,
+        RefData $ref,
+        array $syncedPackageUuids,
+        array $unreadablePaths,
+    ): int {
+        $removed = 0;
+
+        PackageVersion::query()
+            ->whereIn('package_uuid', $repository->packages()->select('uuid'))
+            ->whereNotIn('package_uuid', $syncedPackageUuids)
+            ->where('version', ComposerMetadataData::extractVersion($ref->name))
+            ->get()
+            ->reject(fn (PackageVersion $version) => in_array((string) $version->source_path, $unreadablePaths, true))
+            ->each(function (PackageVersion $version) use (&$removed) {
+                $version->delete();
+                $removed++;
+            });
+
+        if ($removed > 0) {
+            Log::info('Removed versions of packages no longer present at ref', [
+                'repository' => $repository->name,
+                'ref' => $ref->name,
+                'versions_removed' => $removed,
+            ]);
+        }
+
+        return $removed;
+    }
+
+    protected static function join(string $path, string $file): string
+    {
+        return $path === '' ? $file : "{$path}/{$file}";
     }
 }

--- a/app/Domains/Repository/Commands/SyncRepositoryCommand.php
+++ b/app/Domains/Repository/Commands/SyncRepositoryCommand.php
@@ -20,7 +20,8 @@ class SyncRepositoryCommand extends Command
     protected $signature = 'sync:repository
                             {repository? : The UUID of the repository to sync}
                             {--organization= : Sync all repositories for this organization (UUID or slug)}
-                            {--all : Sync all repositories}';
+                            {--all : Sync all repositories}
+                            {--force : Sync every ref, even those whose commit has not changed}';
 
     /**
      * The console command description.
@@ -46,8 +47,10 @@ class SyncRepositoryCommand extends Command
 
         spin(
             callback: function () use ($repositories) {
+                $force = (bool) $this->option('force');
+
                 foreach ($repositories as $repository) {
-                    SyncRepositoryJob::dispatchSync($repository);
+                    SyncRepositoryJob::dispatchSync($repository, $force);
                 }
             },
             message: 'Dispatching sync jobs...',

--- a/app/Domains/Repository/Contracts/Data/SyncRefResultData.php
+++ b/app/Domains/Repository/Contracts/Data/SyncRefResultData.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Domains\Repository\Contracts\Data;
+
+use Spatie\LaravelData\Data;
+
+class SyncRefResultData extends Data
+{
+    public function __construct(
+        public int $added = 0,
+        public int $updated = 0,
+        public int $skipped = 0,
+        public int $removed = 0,
+        public int $packagesFound = 0,
+    ) {}
+}

--- a/app/Domains/Repository/Contracts/Enums/GitProvider.php
+++ b/app/Domains/Repository/Contracts/Enums/GitProvider.php
@@ -63,33 +63,46 @@ enum GitProvider: string
     }
 
     /**
-     * Base URL (with trailing slash) for resolving relative <img src> in a repository file.
+     * Base URL (with trailing slash) for resolving relative <img src> in a repository
+     * file, optionally inside the directory $path of a monorepo package.
      *
      * Returns null for providers where the layout is unknown (generic Git).
      */
-    public function rawFileBaseUrl(string $repoIdentifier, string $ref, ?string $baseUrl = null): ?string
+    public function rawFileBaseUrl(string $repoIdentifier, string $ref, ?string $baseUrl = null, ?string $path = null): ?string
     {
-        return match ($this) {
+        $base = match ($this) {
             self::GitHub => "https://raw.githubusercontent.com/{$repoIdentifier}/{$ref}/",
             self::GitLab => rtrim($baseUrl ?? 'https://gitlab.com', '/')."/{$repoIdentifier}/-/raw/{$ref}/",
             self::Bitbucket => "https://bitbucket.org/{$repoIdentifier}/raw/{$ref}/",
             self::Git => null,
         };
+
+        return $base === null ? null : $base.self::directorySuffix($path);
     }
 
     /**
-     * Base URL (with trailing slash) for resolving relative <a href> in a repository file.
+     * Base URL (with trailing slash) for resolving relative <a href> in a repository
+     * file, optionally inside the directory $path of a monorepo package.
      *
      * Returns null for providers where the layout is unknown (generic Git).
      */
-    public function blobBaseUrl(string $repoIdentifier, string $ref, ?string $baseUrl = null): ?string
+    public function blobBaseUrl(string $repoIdentifier, string $ref, ?string $baseUrl = null, ?string $path = null): ?string
     {
-        return match ($this) {
+        $base = match ($this) {
             self::GitHub => "https://github.com/{$repoIdentifier}/blob/{$ref}/",
             self::GitLab => rtrim($baseUrl ?? 'https://gitlab.com', '/')."/{$repoIdentifier}/-/blob/{$ref}/",
             self::Bitbucket => "https://bitbucket.org/{$repoIdentifier}/src/{$ref}/",
             self::Git => null,
         };
+
+        return $base === null ? null : $base.self::directorySuffix($path);
+    }
+
+    protected static function directorySuffix(?string $path): string
+    {
+        $path = trim((string) $path, '/');
+
+        return $path === '' ? '' : "{$path}/";
     }
 
     /**

--- a/app/Domains/Repository/Jobs/CompleteSyncBatchJob.php
+++ b/app/Domains/Repository/Jobs/CompleteSyncBatchJob.php
@@ -52,12 +52,14 @@ class CompleteSyncBatchJob implements ShouldQueue
         $added = 0;
         $updated = 0;
         $skipped = 0;
+        $removed = 0;
         $failed = 0;
 
         if ($batch) {
             $added = (int) Cache::pull("sync-batch:{$batch->id}:added", 0);
             $updated = (int) Cache::pull("sync-batch:{$batch->id}:updated", 0);
             $skipped = (int) Cache::pull("sync-batch:{$batch->id}:skipped", 0);
+            $removed = (int) Cache::pull("sync-batch:{$batch->id}:removed", 0);
             $failed = $batch->failedJobs;
         }
 
@@ -75,6 +77,8 @@ class CompleteSyncBatchJob implements ShouldQueue
             'versions_updated' => $updated,
             'versions_skipped' => $skipped,
             'versions_failed' => $failed,
+            // Stale tags were removed before the batch ran; refs drop versions too
+            'versions_removed' => $syncLog->versions_removed + $removed,
             'details' => array_merge($syncLog->details ?? [], [
                 'failed_jobs' => $failedJobs,
                 'total_jobs' => $totalJobs,
@@ -87,6 +91,7 @@ class CompleteSyncBatchJob implements ShouldQueue
             'versions_updated' => $updated,
             'versions_skipped' => $skipped,
             'versions_failed' => $failed,
+            'versions_removed' => $syncLog->versions_removed,
         ]);
     }
 

--- a/app/Domains/Repository/Jobs/SyncRefJob.php
+++ b/app/Domains/Repository/Jobs/SyncRefJob.php
@@ -4,11 +4,11 @@ namespace App\Domains\Repository\Jobs;
 
 use App\Domains\Repository\Actions\SyncRefAction;
 use App\Domains\Repository\Contracts\Data\RefData;
+use App\Domains\Repository\Contracts\Data\SyncRefResultData;
 use App\Domains\Repository\Contracts\Enums\GitProvider;
 use App\Domains\Repository\Contracts\Interfaces\GitProviderInterface;
 use App\Domains\Repository\Services\GitProviders\CachedGitProvider;
 use App\Domains\Repository\Services\GitProviders\GitProviderFactory;
-use App\Exceptions\ComposerMetadataException;
 use App\Models\Repository;
 use Illuminate\Bus\Batchable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -45,15 +45,7 @@ class SyncRefJob implements ShouldQueue
         try {
             $result = $syncRefAction->handle($provider, $this->repository, $this->ref);
 
-            $this->incrementCounter($result);
-        } catch (ComposerMetadataException $e) {
-            Log::warning('Skipping ref due to invalid composer.json', [
-                'repository' => $this->repository->name,
-                'ref' => $this->ref->name,
-                'error' => $e->getMessage(),
-            ]);
-
-            $this->incrementCounter('skipped');
+            $this->incrementCounters($result);
         } catch (Throwable $e) {
             Log::error('Failed to sync ref', [
                 'repository' => $this->repository->name,
@@ -78,7 +70,23 @@ class SyncRefJob implements ShouldQueue
         return GitProviderFactory::make($this->repository);
     }
 
-    protected function incrementCounter(string $result): void
+    protected function incrementCounters(SyncRefResultData $result): void
+    {
+        $counters = [
+            'added' => $result->added,
+            'updated' => $result->updated,
+            'skipped' => $result->skipped,
+            'removed' => $result->removed,
+        ];
+
+        foreach ($counters as $counter => $count) {
+            if ($count > 0) {
+                $this->incrementCounter($counter, $count);
+            }
+        }
+    }
+
+    protected function incrementCounter(string $counter, int $count = 1): void
     {
         $batch = $this->batch();
 
@@ -86,7 +94,7 @@ class SyncRefJob implements ShouldQueue
             return;
         }
 
-        Cache::increment("sync-batch:{$batch->id}:{$result}");
+        Cache::increment("sync-batch:{$batch->id}:{$counter}", $count);
     }
 
     public function failed(?Throwable $exception): void

--- a/app/Domains/Repository/Jobs/SyncRepositoryJob.php
+++ b/app/Domains/Repository/Jobs/SyncRepositoryJob.php
@@ -35,7 +35,8 @@ class SyncRepositoryJob implements ShouldBeUnique, ShouldQueue
     public int $uniqueFor = 300;
 
     public function __construct(
-        public Repository $repository
+        public Repository $repository,
+        public bool $force = false,
     ) {}
 
     public function uniqueId(): string
@@ -67,7 +68,8 @@ class SyncRepositoryJob implements ShouldBeUnique, ShouldQueue
             $refs = $collectRefsAction->handle($provider);
 
             $totalRefs = $refs->all->count();
-            $filteredRefs = $filterChangedRefsAction->handle($refs, $this->repository);
+            // A forced sync revisits every ref, e.g. after the package paths changed
+            $filteredRefs = $this->force ? $refs : $filterChangedRefsAction->handle($refs, $this->repository);
             $skippedCount = $totalRefs - $filteredRefs->all->count();
 
             $staleVersionsRemoved = $removeStaleVersionsAction->handle($this->repository, $refs);

--- a/app/Domains/Repository/Services/PackagePaths/PackagePathPattern.php
+++ b/app/Domains/Repository/Services/PackagePaths/PackagePathPattern.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Domains\Repository\Services\PackagePaths;
+
+/**
+ * A configured package location inside a repository: a directory such as
+ * "packages/billing", a single-level wildcard such as "packages/*", or "."
+ * for the repository root. Packages store their directory without the root
+ * marker (null for the root), so matching accepts that form as well.
+ */
+final class PackagePathPattern
+{
+    public const ROOT = '.';
+
+    protected const SEGMENT = '/^[A-Za-z0-9._-]+$/';
+
+    public static function normalize(string $pattern): string
+    {
+        $pattern = trim($pattern);
+
+        if ($pattern === '') {
+            return '';
+        }
+
+        $pattern = preg_replace('#/+#', '/', $pattern) ?? $pattern;
+        $pattern = preg_replace('#^(\./)+#', '', trim($pattern, '/')) ?? $pattern;
+        $pattern = trim($pattern, '/');
+
+        return $pattern === '' || $pattern === self::ROOT ? self::ROOT : $pattern;
+    }
+
+    public static function isValid(string $pattern): bool
+    {
+        $pattern = self::normalize($pattern);
+
+        if ($pattern === '') {
+            return false;
+        }
+
+        if ($pattern === self::ROOT) {
+            return true;
+        }
+
+        $segments = explode('/', $pattern);
+        $last = count($segments) - 1;
+
+        foreach ($segments as $index => $segment) {
+            if ($segment === '*') {
+                if ($index !== $last) {
+                    return false;
+                }
+
+                continue;
+            }
+
+            if (! self::isValidSegment($segment)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static function isValidSegment(string $segment): bool
+    {
+        return $segment !== '.' && $segment !== '..' && preg_match(self::SEGMENT, $segment) === 1;
+    }
+
+    public static function isWildcard(string $pattern): bool
+    {
+        return $pattern === '*' || str_ends_with($pattern, '/*');
+    }
+
+    /**
+     * Directory whose children a wildcard pattern selects ('' for the root).
+     */
+    public static function wildcardParent(string $pattern): string
+    {
+        return $pattern === '*' ? '' : substr($pattern, 0, -2);
+    }
+
+    /**
+     * Whether a package directory (null or '' for the root) is selected by the pattern.
+     */
+    public static function matches(string $pattern, ?string $path): bool
+    {
+        $pattern = self::normalize($pattern);
+        $path = trim((string) $path, '/');
+
+        if ($pattern === self::ROOT) {
+            return $path === '';
+        }
+
+        if ($path === '') {
+            return false;
+        }
+
+        if (self::isWildcard($pattern)) {
+            $slash = strrpos($path, '/');
+            $parent = $slash === false ? '' : substr($path, 0, $slash);
+
+            return $parent === self::wildcardParent($pattern);
+        }
+
+        return $pattern === $path;
+    }
+
+    /**
+     * @param  array<int, string>  $patterns
+     */
+    public static function anyMatches(array $patterns, ?string $path): bool
+    {
+        foreach ($patterns as $pattern) {
+            if (self::matches($pattern, $path)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Feature/Actions/FilterChangedRefsActionTest.php
+++ b/tests/Feature/Actions/FilterChangedRefsActionTest.php
@@ -226,3 +226,37 @@ it('handles tags without v prefix', function () {
 
     expect($result->all->count())->toBe(0);
 });
+
+it('keeps a ref while any package of the repository sits at a stale commit', function () {
+    $organization = Organization::factory()->create();
+    $repository = Repository::factory()->for($organization, 'organization')->github()->create();
+    $billing = Package::factory()->forOrganization($organization)->forRepository($repository)->create();
+    $crm = Package::factory()->forOrganization($organization)->forRepository($repository)->create();
+
+    PackageVersion::factory()->forPackage($billing)->create(['version' => 'v1.0.0', 'source_reference' => 'abc123']);
+    PackageVersion::factory()->forPackage($crm)->create(['version' => 'v1.0.0', 'source_reference' => 'stale']);
+
+    $result = app(FilterChangedRefsAction::class)->handle(
+        makeRefs(tags: [['name' => 'v1.0.0', 'commit' => 'abc123']]),
+        $repository,
+    );
+
+    expect($result->all->count())->toBe(1);
+});
+
+it('filters a ref once every package sits at its commit', function () {
+    $organization = Organization::factory()->create();
+    $repository = Repository::factory()->for($organization, 'organization')->github()->create();
+    $billing = Package::factory()->forOrganization($organization)->forRepository($repository)->create();
+    $crm = Package::factory()->forOrganization($organization)->forRepository($repository)->create();
+
+    PackageVersion::factory()->forPackage($billing)->create(['version' => 'v1.0.0', 'source_reference' => 'abc123']);
+    PackageVersion::factory()->forPackage($crm)->create(['version' => 'v1.0.0', 'source_reference' => 'abc123']);
+
+    $result = app(FilterChangedRefsAction::class)->handle(
+        makeRefs(tags: [['name' => 'v1.0.0', 'commit' => 'abc123']]),
+        $repository,
+    );
+
+    expect($result->all->count())->toBe(0);
+});

--- a/tests/Feature/Composer/DistDownloadAfterBranchSyncTest.php
+++ b/tests/Feature/Composer/DistDownloadAfterBranchSyncTest.php
@@ -2,6 +2,7 @@
 
 use App\Domains\Repository\Actions\SyncRefAction;
 use App\Domains\Repository\Contracts\Data\RefData;
+use App\Domains\Repository\Contracts\Data\SyncRefResultData;
 use App\Domains\Repository\Contracts\Interfaces\GitProviderInterface;
 use App\Models\AccessToken;
 use App\Models\DistArchive;
@@ -31,8 +32,9 @@ beforeEach(function () {
         ->neverExpires()
         ->create();
 
-    $this->syncBranch = function (string $commit): string {
+    $this->syncBranch = function (string $commit): SyncRefResultData {
         $provider = Mockery::mock(GitProviderInterface::class);
+        $provider->shouldReceive('listDirectory')->andReturn([]);
 
         $provider->shouldReceive('getFileContent')
             ->andReturnUsing(fn (string $ref, string $path) => $path === 'composer.json'
@@ -61,8 +63,8 @@ it('keeps a locked branch commit installable after the branch head moves', funct
     $lockedCommit = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
     $newCommit = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 
-    expect(($this->syncBranch)($lockedCommit))->toBe('added');
-    expect(($this->syncBranch)($newCommit))->toBe('updated');
+    expect(($this->syncBranch)($lockedCommit)->added)->toBe(1);
+    expect(($this->syncBranch)($newCommit)->updated)->toBe(1);
 
     // The branch keeps a single row, so it now points at the new head.
     $packageVersion = PackageVersion::query()->sole();

--- a/tests/Feature/Composer/VersionMetadataDistTest.php
+++ b/tests/Feature/Composer/VersionMetadataDistTest.php
@@ -45,3 +45,37 @@ it('excludes dist info when dist_url is null', function () {
 
     expect($array)->not->toHaveKey('dist');
 });
+
+it('omits the source block for versions read from a subdirectory', function () {
+    $organization = Organization::factory()->create();
+    $package = Package::factory()->for($organization, 'organization')->atPath('packages/billing')->create(['name' => 'acme/billing']);
+    $version = PackageVersion::factory()->for($package)->atPath('packages/billing')->create([
+        'version' => '1.0.0',
+        'normalized_version' => '1.0.0.0',
+        'source_url' => 'git@github.com:acme/monorepo.git',
+        'source_reference' => 'abc123',
+        'dist_url' => 'https://example.com/dists/acme/billing/1.0.0/abc123.zip',
+        'dist_shasum' => 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
+    ]);
+
+    $array = VersionMetadataData::fromPackageVersion($version)->toArray();
+
+    expect($array)->not->toHaveKey('source')
+        ->and($array['dist']['reference'])->toBe('abc123');
+});
+
+it('keeps the source block for versions read from the repository root', function () {
+    $organization = Organization::factory()->create();
+    $package = Package::factory()->for($organization, 'organization')->create(['name' => 'acme/test-package']);
+    $version = PackageVersion::factory()->for($package)->create([
+        'source_url' => 'git@github.com:acme/test-package.git',
+        'source_reference' => 'abc123',
+    ]);
+
+    expect(VersionMetadataData::fromPackageVersion($version)->toArray()['source'])->toBe([
+        'type' => 'git',
+        'url' => 'git@github.com:acme/test-package.git',
+        'reference' => 'abc123',
+        'shasum' => null,
+    ]);
+});

--- a/tests/Feature/Domains/Repository/FetchReadmeActionTest.php
+++ b/tests/Feature/Domains/Repository/FetchReadmeActionTest.php
@@ -4,60 +4,67 @@ use App\Domains\Repository\Actions\FetchReadmeAction;
 use App\Domains\Repository\Contracts\Interfaces\GitProviderInterface;
 use App\Domains\Repository\Exceptions\GitProviderException;
 
-it('returns the contents of the first README candidate found', function () {
+/**
+ * @param  array<int, string>  $files
+ */
+function readmeProvider(array $files, string $path = ''): GitProviderInterface
+{
     $provider = Mockery::mock(GitProviderInterface::class);
-    $provider->shouldReceive('getFileContent')
-        ->with('main', 'README.md')
-        ->andReturn('# Hello');
-    $provider->shouldNotReceive('getFileContent')->with('main', 'readme.md');
+    $provider->shouldReceive('getRepositoryIdentifier')->andReturn('vendor/pkg');
+    $provider->shouldReceive('listDirectory')
+        ->with('main', $path)
+        ->andReturn(array_map(fn (string $name) => ['name' => $name, 'type' => 'file'], $files));
 
-    $result = (new FetchReadmeAction)->handle($provider, 'main');
+    return $provider;
+}
 
-    expect($result)->toBe('# Hello');
+it('returns the README found in the directory listing', function () {
+    $provider = readmeProvider(['composer.json', 'README.md']);
+    $provider->shouldReceive('getFileContent')->with('main', 'README.md')->once()->andReturn('# Hello');
+
+    expect((new FetchReadmeAction)->handle($provider, 'main'))->toBe('# Hello');
 });
 
-it('falls back to alternate filenames', function () {
-    $provider = Mockery::mock(GitProviderInterface::class);
-    $provider->shouldReceive('getFileContent')->with('main', 'README.md')->andReturn(null);
-    $provider->shouldReceive('getFileContent')->with('main', 'readme.md')->andReturn('lowercase');
-    $provider->shouldReceive('getFileContent')->byDefault()->andReturn(null);
+it('matches README filenames case-insensitively', function () {
+    $provider = readmeProvider(['readme.md']);
+    $provider->shouldReceive('getFileContent')->with('main', 'readme.md')->once()->andReturn('lowercase');
 
-    $result = (new FetchReadmeAction)->handle($provider, 'main');
-
-    expect($result)->toBe('lowercase');
+    expect((new FetchReadmeAction)->handle($provider, 'main'))->toBe('lowercase');
 });
 
-it('returns null when no candidate filename exists', function () {
-    $provider = Mockery::mock(GitProviderInterface::class);
-    $provider->shouldReceive('getFileContent')->andReturn(null);
+it('prefers README.md over the other candidates', function () {
+    $provider = readmeProvider(['README', 'README.markdown', 'README.md']);
+    $provider->shouldReceive('getFileContent')->with('main', 'README.md')->once()->andReturn('markdown');
 
-    $result = (new FetchReadmeAction)->handle($provider, 'main');
+    expect((new FetchReadmeAction)->handle($provider, 'main'))->toBe('markdown');
+});
 
-    expect($result)->toBeNull();
+it('reads the README of a subdirectory', function () {
+    $provider = readmeProvider(['README.md'], 'packages/billing');
+    $provider->shouldReceive('getFileContent')->with('main', 'packages/billing/README.md')->once()->andReturn('# Billing');
+
+    expect((new FetchReadmeAction)->handle($provider, 'main', 'packages/billing/'))->toBe('# Billing');
+});
+
+it('returns null when the directory holds no README', function () {
+    $provider = readmeProvider(['composer.json', 'src']);
+    $provider->shouldNotReceive('getFileContent');
+
+    expect((new FetchReadmeAction)->handle($provider, 'main'))->toBeNull();
 });
 
 it('rejects READMEs above the size cap', function () {
-    $oversized = str_repeat('a', 513 * 1024);
+    $provider = readmeProvider(['README.md']);
+    $provider->shouldReceive('getFileContent')->with('main', 'README.md')->andReturn(str_repeat('a', 513 * 1024));
 
-    $provider = Mockery::mock(GitProviderInterface::class);
-    $provider->shouldReceive('getRepositoryIdentifier')->andReturn('vendor/pkg');
-    $provider->shouldReceive('getFileContent')->with('main', 'README.md')->andReturn($oversized);
-
-    $result = (new FetchReadmeAction)->handle($provider, 'main');
-
-    expect($result)->toBeNull();
+    expect((new FetchReadmeAction)->handle($provider, 'main'))->toBeNull();
 });
 
-it('returns null and stops probing when the provider throws', function () {
+it('returns null when the provider throws', function () {
     $provider = Mockery::mock(GitProviderInterface::class);
     $provider->shouldReceive('getRepositoryIdentifier')->andReturn('vendor/pkg');
-    $provider->shouldReceive('getFileContent')
-        ->with('main', 'README.md')
-        ->once()
-        ->andThrow(new GitProviderException('rate limited'));
-    $provider->shouldNotReceive('getFileContent')->with('main', 'readme.md');
+    $provider->shouldReceive('listDirectory')->once()->andThrow(new GitProviderException('rate limited'));
+    $provider->shouldNotReceive('getFileContent');
 
-    $result = (new FetchReadmeAction)->handle($provider, 'main');
-
-    expect($result)->toBeNull();
+    expect((new FetchReadmeAction)->handle($provider, 'main'))->toBeNull();
 });

--- a/tests/Feature/Domains/Repository/FindOrCreatePackageActionTest.php
+++ b/tests/Feature/Domains/Repository/FindOrCreatePackageActionTest.php
@@ -1,6 +1,9 @@
 <?php
 
+use App\Domains\Activity\Contracts\Enums\ActivityType;
 use App\Domains\Repository\Actions\FindOrCreatePackageAction;
+use App\Models\ActivityLog;
+use App\Models\Mirror;
 use App\Models\Organization;
 use App\Models\Package;
 use App\Models\Repository;
@@ -56,4 +59,69 @@ it('does not create a duplicate when called concurrently', function () {
 
     expect($package->name)->toBe('vendor/race-package');
     expect(Package::where('name', 'vendor/race-package')->count())->toBe(1);
+});
+
+it('stores the source path of a newly discovered package and records the activity', function () {
+    $repository = Repository::factory()->create();
+
+    $package = app(FindOrCreatePackageAction::class)->handle($repository, 'vendor/billing', 'packages/billing');
+
+    expect($package?->source_path)->toBe('packages/billing')
+        ->and(ActivityLog::query()->where('type', ActivityType::PackageCreated->value)->count())->toBe(1);
+});
+
+it('updates the source path when a package moved', function () {
+    $organization = Organization::factory()->create();
+    $repository = Repository::factory()->forOrganization($organization)->create();
+    $existing = Package::factory()->forOrganization($organization)->forRepository($repository)
+        ->atPath('src/billing')->create(['name' => 'vendor/billing']);
+
+    $package = app(FindOrCreatePackageAction::class)->handle($repository, 'vendor/billing', 'packages/billing');
+
+    expect($package?->uuid)->toBe($existing->uuid)
+        ->and($existing->fresh()?->source_path)->toBe('packages/billing')
+        ->and(ActivityLog::count())->toBe(0);
+});
+
+it('clears the source path when a package moved back to the root', function () {
+    $organization = Organization::factory()->create();
+    $repository = Repository::factory()->forOrganization($organization)->create();
+    Package::factory()->forOrganization($organization)->forRepository($repository)
+        ->atPath('packages/billing')->create(['name' => 'vendor/billing']);
+
+    $package = app(FindOrCreatePackageAction::class)->handle($repository, 'vendor/billing');
+
+    expect($package?->fresh()?->source_path)->toBeNull();
+});
+
+it('refuses a name owned by another repository', function () {
+    $organization = Organization::factory()->create();
+    $owner = Repository::factory()->forOrganization($organization)->create();
+    $repository = Repository::factory()->forOrganization($organization)->create();
+    Package::factory()->forOrganization($organization)->forRepository($owner)->create(['name' => 'vendor/billing']);
+
+    expect(app(FindOrCreatePackageAction::class)->handle($repository, 'vendor/billing'))->toBeNull()
+        ->and(Package::query()->where('name', 'vendor/billing')->sole()->repository_uuid)->toBe($owner->uuid);
+});
+
+it('refuses a name owned by a mirror', function () {
+    $organization = Organization::factory()->create();
+    $repository = Repository::factory()->forOrganization($organization)->create();
+    $mirror = Mirror::factory()->create(['organization_uuid' => $organization->uuid]);
+    Package::factory()->forOrganization($organization)->withoutRepository()
+        ->create(['name' => 'vendor/billing', 'mirror_uuid' => $mirror->uuid]);
+
+    expect(app(FindOrCreatePackageAction::class)->handle($repository, 'vendor/billing'))->toBeNull();
+});
+
+it('adopts a package that has no source yet', function () {
+    $organization = Organization::factory()->create();
+    $repository = Repository::factory()->forOrganization($organization)->create();
+    $orphan = Package::factory()->forOrganization($organization)->withoutRepository()->create(['name' => 'vendor/billing']);
+
+    $package = app(FindOrCreatePackageAction::class)->handle($repository, 'vendor/billing', 'packages/billing');
+
+    expect($package?->uuid)->toBe($orphan->uuid)
+        ->and($orphan->fresh()?->repository_uuid)->toBe($repository->uuid)
+        ->and($orphan->fresh()?->source_path)->toBe('packages/billing');
 });

--- a/tests/Feature/Domains/Repository/ResolvePackagePathsActionTest.php
+++ b/tests/Feature/Domains/Repository/ResolvePackagePathsActionTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use App\Domains\Repository\Actions\ResolvePackagePathsAction;
+use App\Domains\Repository\Contracts\Interfaces\GitProviderInterface;
+use App\Models\Repository;
+
+/**
+ * @param  array<string, array<int, array{name: string, type: string}>>  $directories  path => entries
+ */
+function directoryListingProvider(array $directories = []): GitProviderInterface
+{
+    $provider = Mockery::mock(GitProviderInterface::class);
+    $provider->shouldReceive('listDirectory')
+        ->andReturnUsing(fn (string $ref, string $path) => $directories[$path] ?? []);
+
+    return $provider;
+}
+
+it('resolves to the root when no package paths are configured', function () {
+    $provider = Mockery::mock(GitProviderInterface::class);
+    $provider->shouldNotReceive('listDirectory');
+
+    $action = app(ResolvePackagePathsAction::class);
+
+    expect($action->handle($provider, Repository::factory()->create(), 'main'))->toBe([''])
+        ->and($action->handle($provider, Repository::factory()->withPackagePaths([])->create(), 'main'))->toBe(['']);
+});
+
+it('returns literal directories and the root when listed', function () {
+    $repository = Repository::factory()->withPackagePaths(['packages/billing', '.', 'packages/crm/'])->create();
+
+    expect(app(ResolvePackagePathsAction::class)->handle(directoryListingProvider(), $repository, 'main'))
+        ->toBe(['', 'packages/billing', 'packages/crm']);
+});
+
+it('leaves the root out unless it is listed', function () {
+    $repository = Repository::factory()->withPackagePaths(['packages/billing'])->create();
+
+    expect(app(ResolvePackagePathsAction::class)->handle(directoryListingProvider(), $repository, 'main'))
+        ->toBe(['packages/billing']);
+});
+
+it('expands a wildcard to the subdirectories of its parent', function () {
+    $repository = Repository::factory()->withPackagePaths(['packages/*'])->create();
+
+    $provider = directoryListingProvider([
+        'packages' => [
+            ['name' => 'crm', 'type' => 'dir'],
+            ['name' => 'billing', 'type' => 'dir'],
+            ['name' => 'README.md', 'type' => 'file'],
+            ['name' => '.hidden', 'type' => 'dir'],
+            ['name' => 'bad name', 'type' => 'dir'],
+        ],
+    ]);
+
+    expect(app(ResolvePackagePathsAction::class)->handle($provider, $repository, 'v1.0.0'))
+        ->toBe(['packages/billing', 'packages/crm']);
+});
+
+it('expands a bare wildcard against the repository root', function () {
+    $repository = Repository::factory()->withPackagePaths(['*'])->create();
+
+    $provider = directoryListingProvider([
+        '' => [
+            ['name' => 'billing', 'type' => 'dir'],
+            ['name' => 'composer.json', 'type' => 'file'],
+        ],
+    ]);
+
+    expect(app(ResolvePackagePathsAction::class)->handle($provider, $repository, 'main'))->toBe(['billing']);
+});
+
+it('deduplicates overlapping patterns and ignores invalid ones', function () {
+    $repository = Repository::factory()->withPackagePaths(['packages/*', 'packages/billing', '../escape', 'packages/*/src'])->create();
+
+    $provider = directoryListingProvider([
+        'packages' => [['name' => 'billing', 'type' => 'dir']],
+    ]);
+
+    expect(app(ResolvePackagePathsAction::class)->handle($provider, $repository, 'main'))->toBe(['packages/billing']);
+});

--- a/tests/Feature/Domains/Repository/SyncRefActionMonorepoTest.php
+++ b/tests/Feature/Domains/Repository/SyncRefActionMonorepoTest.php
@@ -1,0 +1,267 @@
+<?php
+
+use App\Domains\Activity\Contracts\Enums\ActivityType;
+use App\Domains\Composer\Contracts\Data\VersionMetadataData;
+use App\Domains\Repository\Actions\SyncRefAction;
+use App\Domains\Repository\Contracts\Data\RefData;
+use App\Domains\Repository\Contracts\Interfaces\GitProviderInterface;
+use App\Models\ActivityLog;
+use App\Models\Organization;
+use App\Models\Package;
+use App\Models\PackageVersion;
+use App\Models\Repository;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * @param  array<string, string>  $files  path => contents
+ * @param  array<string, array<int, array{name: string, type: string}>>  $directories  path => entries
+ */
+function monorepoProvider(array $files, array $directories = []): GitProviderInterface
+{
+    $provider = Mockery::mock(GitProviderInterface::class);
+    $provider->shouldReceive('getFileContent')
+        ->andReturnUsing(fn (string $ref, string $path) => $files[$path] ?? null);
+    $provider->shouldReceive('listDirectory')
+        ->andReturnUsing(fn (string $ref, string $path) => $directories[trim($path, '/')] ?? []);
+    $provider->shouldReceive('getRepositoryUrl')->andReturn('https://github.com/acme/monorepo.git');
+    $provider->shouldReceive('getRepositoryIdentifier')->andReturn('acme/monorepo');
+    $provider->shouldReceive('downloadArchive')
+        ->andReturnUsing(function (string $ref, string $outputPath, ?string $path = null) {
+            file_put_contents($outputPath, "zip-{$ref}-".($path ?? 'root'));
+
+            return true;
+        });
+
+    return $provider;
+}
+
+function monorepoComposerJson(string $name): string
+{
+    return (string) json_encode(['name' => $name, 'type' => 'library']);
+}
+
+beforeEach(function () {
+    Storage::fake('local');
+
+    $this->organization = Organization::factory()->create(['slug' => 'acme']);
+    $this->repository = Repository::factory()
+        ->github()
+        ->forOrganization($this->organization)
+        ->withPackagePaths(['packages/*'])
+        ->create();
+
+    $this->packagesListing = [
+        'packages' => [
+            ['name' => 'billing', 'type' => 'dir'],
+            ['name' => 'crm', 'type' => 'dir'],
+            ['name' => 'README.md', 'type' => 'file'],
+        ],
+    ];
+
+    $this->sync = fn (GitProviderInterface $provider, string $ref = 'main', string $commit = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa') => app(SyncRefAction::class)
+        ->handle($provider, $this->repository, new RefData(name: $ref, commit: $commit));
+});
+
+it('syncs every package found under the configured paths and leaves the root alone', function () {
+    $provider = monorepoProvider([
+        'composer.json' => monorepoComposerJson('acme/monorepo'),
+        'packages/billing/composer.json' => monorepoComposerJson('acme/billing'),
+        'packages/crm/composer.json' => monorepoComposerJson('acme/crm'),
+    ], $this->packagesListing);
+
+    $commit = 'abc123def4567890abc123def4567890abc123de';
+    $result = ($this->sync)($provider, 'v1.0.0', $commit);
+
+    expect($result->added)->toBe(2)
+        ->and($result->packagesFound)->toBe(2)
+        ->and($result->skipped)->toBe(0)
+        ->and($result->removed)->toBe(0)
+        ->and(Package::query()->orderBy('name')->pluck('name')->all())->toBe(['acme/billing', 'acme/crm']);
+
+    $billing = Package::query()->where('name', 'acme/billing')->sole();
+    $version = $billing->versions()->sole();
+
+    expect($billing->source_path)->toBe('packages/billing')
+        ->and($billing->repository_uuid)->toBe($this->repository->uuid)
+        ->and($version->version)->toBe('v1.0.0')
+        ->and($version->source_path)->toBe('packages/billing')
+        ->and($version->source_reference)->toBe($commit)
+        ->and($version->dist_shasum)->toBe(sha1("zip-{$commit}-packages/billing"));
+
+    expect(VersionMetadataData::fromPackageVersion($version)->toArray())
+        ->not->toHaveKey('source')
+        ->toHaveKey('dist');
+});
+
+it('includes the root package only when the root is listed', function () {
+    $this->repository->update(['package_paths' => ['.', 'packages/*']]);
+
+    $provider = monorepoProvider([
+        'composer.json' => monorepoComposerJson('acme/monorepo'),
+        'packages/billing/composer.json' => monorepoComposerJson('acme/billing'),
+        'packages/crm/composer.json' => monorepoComposerJson('acme/crm'),
+    ], $this->packagesListing);
+
+    $result = ($this->sync)($provider);
+
+    expect($result->added)->toBe(3)
+        ->and(Package::query()->where('name', 'acme/monorepo')->sole()->source_path)->toBeNull()
+        ->and(PackageVersion::query()->whereNull('source_path')->count())->toBe(1);
+});
+
+it('reads the README from the package directory', function () {
+    $provider = monorepoProvider([
+        'packages/billing/composer.json' => monorepoComposerJson('acme/billing'),
+        'packages/billing/readme.md' => '# Billing',
+        'README.md' => '# Monorepo',
+    ], $this->packagesListing + [
+        'packages/billing' => [
+            ['name' => 'composer.json', 'type' => 'file'],
+            ['name' => 'readme.md', 'type' => 'file'],
+        ],
+    ]);
+
+    ($this->sync)($provider);
+
+    expect(PackageVersion::query()->sole()->readme)->toBe('# Billing');
+});
+
+it('counts directories without a composer.json as skipped', function () {
+    $provider = monorepoProvider([
+        'packages/billing/composer.json' => monorepoComposerJson('acme/billing'),
+    ], $this->packagesListing);
+
+    $result = ($this->sync)($provider);
+
+    expect($result->added)->toBe(1)
+        ->and($result->skipped)->toBe(1)
+        ->and(Package::count())->toBe(1);
+});
+
+it('keeps syncing the other packages when one composer.json is invalid and leaves that package alone', function () {
+    $crm = Package::factory()->forOrganization($this->organization)->forRepository($this->repository)
+        ->atPath('packages/crm')->create(['name' => 'acme/crm']);
+    $existing = PackageVersion::factory()->forPackage($crm)->devBranch('main')->atPath('packages/crm')
+        ->create(['source_reference' => 'oldoldoldoldoldoldoldoldoldoldoldoldoldo']);
+
+    $provider = monorepoProvider([
+        'packages/billing/composer.json' => monorepoComposerJson('acme/billing'),
+        'packages/crm/composer.json' => '{"name": "acme/crm", ',
+    ], $this->packagesListing);
+
+    $result = ($this->sync)($provider);
+
+    expect($result->added)->toBe(1)
+        ->and($result->skipped)->toBe(1)
+        ->and($result->removed)->toBe(0)
+        ->and($existing->fresh()?->source_reference)->toBe('oldoldoldoldoldoldoldoldoldoldoldoldoldo');
+});
+
+it('skips a second directory declaring an already seen package name', function () {
+    $provider = monorepoProvider([
+        'packages/billing/composer.json' => monorepoComposerJson('acme/billing'),
+        'packages/crm/composer.json' => monorepoComposerJson('acme/billing'),
+    ], $this->packagesListing);
+
+    $result = ($this->sync)($provider);
+
+    expect($result->added)->toBe(1)
+        ->and($result->skipped)->toBe(1)
+        ->and(Package::count())->toBe(1)
+        ->and(PackageVersion::query()->sole()->source_path)->toBe('packages/billing');
+});
+
+it('does not attach versions to a package owned by another repository', function () {
+    $otherRepository = Repository::factory()->github()->forOrganization($this->organization)->create();
+    Package::factory()->forOrganization($this->organization)->forRepository($otherRepository)->create(['name' => 'acme/billing']);
+
+    $provider = monorepoProvider([
+        'packages/billing/composer.json' => monorepoComposerJson('acme/billing'),
+        'packages/crm/composer.json' => monorepoComposerJson('acme/crm'),
+    ], $this->packagesListing);
+
+    $result = ($this->sync)($provider);
+
+    expect($result->added)->toBe(1)
+        ->and($result->skipped)->toBe(1)
+        ->and(Package::query()->where('name', 'acme/billing')->sole()->repository_uuid)->toBe($otherRepository->uuid)
+        ->and(Package::query()->where('name', 'acme/billing')->sole()->versions()->count())->toBe(0);
+});
+
+it('removes the ref version of a package that vanished from the ref', function () {
+    $crm = Package::factory()->forOrganization($this->organization)->forRepository($this->repository)
+        ->atPath('packages/crm')->create(['name' => 'acme/crm']);
+    PackageVersion::factory()->forPackage($crm)->devBranch('main')->atPath('packages/crm')->create();
+    PackageVersion::factory()->forPackage($crm)->atPath('packages/crm')->create(['version' => 'v1.0.0']);
+
+    $provider = monorepoProvider([
+        'packages/billing/composer.json' => monorepoComposerJson('acme/billing'),
+    ], ['packages' => [['name' => 'billing', 'type' => 'dir']]]);
+
+    $result = ($this->sync)($provider);
+
+    expect($result->added)->toBe(1)
+        ->and($result->removed)->toBe(1)
+        ->and($crm->versions()->pluck('version')->all())->toBe(['v1.0.0']);
+});
+
+it('records an activity for each newly discovered package', function () {
+    $provider = monorepoProvider([
+        'packages/billing/composer.json' => monorepoComposerJson('acme/billing'),
+        'packages/crm/composer.json' => monorepoComposerJson('acme/crm'),
+    ], $this->packagesListing);
+
+    ($this->sync)($provider);
+    ($this->sync)($provider, 'v1.0.0', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+
+    expect(ActivityLog::query()->where('type', ActivityType::PackageCreated->value)->count())->toBe(2);
+});
+
+it('moves a package that changed directory at the same commit', function () {
+    $commit = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    $billing = Package::factory()->forOrganization($this->organization)->forRepository($this->repository)
+        ->atPath('src/billing')->create(['name' => 'acme/billing']);
+    $version = PackageVersion::factory()->forPackage($billing)->devBranch('main')->atPath('src/billing')
+        ->create(['source_reference' => $commit]);
+
+    $provider = monorepoProvider([
+        'packages/billing/composer.json' => monorepoComposerJson('acme/billing'),
+    ], ['packages' => [['name' => 'billing', 'type' => 'dir']]]);
+
+    $result = ($this->sync)($provider, 'main', $commit);
+
+    expect($result->updated)->toBe(1)
+        ->and($version->fresh()?->source_path)->toBe('packages/billing')
+        ->and($billing->fresh()?->source_path)->toBe('packages/billing');
+});
+
+it('skips a package whose ref already sits at the same commit and location', function () {
+    $provider = monorepoProvider([
+        'packages/billing/composer.json' => monorepoComposerJson('acme/billing'),
+    ], ['packages' => [['name' => 'billing', 'type' => 'dir']]]);
+
+    ($this->sync)($provider);
+    $result = ($this->sync)($provider);
+
+    expect($result->added)->toBe(0)
+        ->and($result->skipped)->toBe(1)
+        ->and($result->packagesFound)->toBe(1)
+        ->and($result->removed)->toBe(0);
+});
+
+it('keeps the classic root package flow for repositories without configured paths', function () {
+    $this->repository->update(['package_paths' => null]);
+
+    $provider = monorepoProvider([
+        'composer.json' => monorepoComposerJson('acme/monorepo'),
+        'packages/billing/composer.json' => monorepoComposerJson('acme/billing'),
+    ]);
+
+    $result = ($this->sync)($provider);
+    $version = PackageVersion::query()->sole();
+
+    expect($result->added)->toBe(1)
+        ->and(Package::query()->sole()->name)->toBe('acme/monorepo')
+        ->and($version->source_path)->toBeNull()
+        ->and(VersionMetadataData::fromPackageVersion($version)->toArray())->toHaveKey('source');
+});

--- a/tests/Feature/Domains/Repository/SyncRefDistTest.php
+++ b/tests/Feature/Domains/Repository/SyncRefDistTest.php
@@ -3,6 +3,7 @@
 use App\Domains\Composer\Contracts\Data\VersionMetadataData;
 use App\Domains\Repository\Actions\SyncRefAction;
 use App\Domains\Repository\Contracts\Data\RefData;
+use App\Domains\Repository\Contracts\Data\SyncRefResultData;
 use App\Domains\Repository\Contracts\Interfaces\GitProviderInterface;
 use App\Models\Organization;
 use App\Models\PackageVersion;
@@ -18,8 +19,9 @@ beforeEach(function () {
         ->forOrganization($this->organization)
         ->create();
 
-    $this->syncBranch = function (string $commit, bool $archiveSucceeds = true): string {
+    $this->syncBranch = function (string $commit, bool $archiveSucceeds = true): SyncRefResultData {
         $provider = Mockery::mock(GitProviderInterface::class);
+        $provider->shouldReceive('listDirectory')->andReturn([]);
 
         $provider->shouldReceive('getFileContent')
             ->andReturnUsing(fn (string $ref, string $path) => $path === 'composer.json'

--- a/tests/Feature/Jobs/CompleteSyncBatchJobTest.php
+++ b/tests/Feature/Jobs/CompleteSyncBatchJobTest.php
@@ -1,10 +1,13 @@
 <?php
 
 use App\Domains\Activity\Actions\RecordActivityTask;
+use App\Domains\Repository\Actions\CleanupGitCloneAction;
 use App\Domains\Repository\Jobs\CompleteSyncBatchJob;
 use App\Models\Organization;
 use App\Models\Repository;
 use App\Models\RepositorySyncLog;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 
 it('skips recording activity when the organization was deleted during a repository sync', function () {
@@ -35,4 +38,21 @@ it('skips recording activity when the organization was deleted during a reposito
             'organization_uuid' => $organization->uuid,
             'sync_log_uuid' => $syncLog->uuid,
         ]);
+});
+
+it('adds versions removed per ref to the stale version count', function () {
+    $organization = Organization::factory()->create();
+    $repository = Repository::factory()->for($organization)->create();
+    $syncLog = RepositorySyncLog::factory()->for($repository)->pending()->create(['versions_removed' => 2]);
+
+    $batch = Bus::batch([])->dispatch();
+    Cache::put("sync-batch:{$batch->id}:added", 1);
+    Cache::put("sync-batch:{$batch->id}:removed", 3);
+
+    (new CompleteSyncBatchJob($syncLog->uuid, $repository->uuid, null, $batch->id))
+        ->handle(app(CleanupGitCloneAction::class), app(RecordActivityTask::class));
+
+    expect($syncLog->fresh()?->versions_removed)->toBe(5)
+        ->and($syncLog->fresh()?->versions_added)->toBe(1)
+        ->and(Cache::get("sync-batch:{$batch->id}:removed"))->toBeNull();
 });

--- a/tests/Feature/Jobs/SyncRefJobTest.php
+++ b/tests/Feature/Jobs/SyncRefJobTest.php
@@ -139,7 +139,7 @@ it('skips refs when composer.json is missing', function () {
     $syncRefAction = app(SyncRefAction::class);
     $result = $syncRefAction->handle($mockProvider, $repository, $ref);
 
-    expect($result)->toBe('skipped');
+    expect($result->skipped)->toBe(1);
     expect(Package::count())->toBe(0);
     expect(PackageVersion::count())->toBe(0);
 });

--- a/tests/Feature/Jobs/SyncRepositoryJobForceTest.php
+++ b/tests/Feature/Jobs/SyncRepositoryJobForceTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Domains\Repository\Actions\CollectRefsAction;
+use App\Domains\Repository\Actions\CreateGitCloneAction;
+use App\Domains\Repository\Actions\CreateSyncLogAction;
+use App\Domains\Repository\Actions\FilterChangedRefsAction;
+use App\Domains\Repository\Actions\RemoveStaleVersionsAction;
+use App\Domains\Repository\Jobs\SyncRepositoryJob;
+use App\Models\Organization;
+use App\Models\Package;
+use App\Models\PackageVersion;
+use App\Models\Repository;
+use App\Models\User;
+use App\Models\UserGitCredential;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    Http::fake([
+        'api.github.com/repos/*/tags*' => Http::response([
+            ['name' => 'v1.0.0', 'commit' => ['sha' => 'abc123']],
+        ]),
+        'api.github.com/repos/*/branches*' => Http::response([]),
+        'api.github.com/repos/*' => Http::response(['name' => 'test-repo', 'full_name' => 'owner/test-repo']),
+    ]);
+
+    $user = User::factory()->create();
+    $organization = Organization::factory()->create();
+    $this->repository = Repository::factory()
+        ->for($organization, 'organization')
+        ->github()
+        ->create(['credential_user_uuid' => $user->uuid]);
+
+    UserGitCredential::factory()->for($user, 'user')->github()->create();
+
+    $package = Package::factory()->forOrganization($organization)->forRepository($this->repository)->create();
+    PackageVersion::factory()->forPackage($package)->create([
+        'version' => 'v1.0.0',
+        'source_reference' => 'abc123',
+    ]);
+
+    $this->runJob = fn (bool $force) => (new SyncRepositoryJob($this->repository, force: $force))->handle(
+        app(CreateSyncLogAction::class),
+        app(CollectRefsAction::class),
+        app(CreateGitCloneAction::class),
+        app(FilterChangedRefsAction::class),
+        app(RemoveStaleVersionsAction::class),
+    );
+});
+
+it('leaves unchanged refs out of the batch by default', function () {
+    Bus::fake();
+
+    ($this->runJob)(false);
+
+    Bus::assertNothingBatched();
+});
+
+it('syncs every ref when forced', function () {
+    Bus::fake();
+
+    ($this->runJob)(true);
+
+    Bus::assertBatched(fn ($batch) => $batch->jobs->count() === 1);
+});

--- a/tests/Feature/PackageVersionSubdirectoryReadmeTest.php
+++ b/tests/Feature/PackageVersionSubdirectoryReadmeTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Domains\Package\Contracts\Data\PackageVersionDetailData;
+use App\Domains\Repository\Contracts\Enums\GitProvider;
+use App\Models\Package;
+use App\Models\PackageVersion;
+
+it('resolves relative README links against the package directory', function () {
+    $package = Package::factory()->atPath('packages/billing')->create();
+    $version = PackageVersion::factory()->forPackage($package)->atPath('packages/billing')->create([
+        'source_reference' => 'abc123',
+        'readme' => "![logo](docs/logo.png)\n\n[guide](GUIDE.md)",
+    ]);
+
+    $detail = PackageVersionDetailData::fromModel($version, GitProvider::GitHub, 'acme/mono');
+
+    expect($detail->readmeHtml)
+        ->toContain('https://raw.githubusercontent.com/acme/mono/abc123/packages/billing/docs/logo.png')
+        ->toContain('https://github.com/acme/mono/blob/abc123/packages/billing/GUIDE.md');
+});

--- a/tests/Feature/SyncRepositoryCommandTest.php
+++ b/tests/Feature/SyncRepositoryCommandTest.php
@@ -115,3 +115,21 @@ it('can sync all repositories with --all flag', function () {
         ->expectsOutput('Found 2 repository/repositories to sync.')
         ->assertSuccessful();
 });
+
+it('accepts the --force option', function () {
+    $user = User::factory()->create();
+    $organization = Organization::factory()->create();
+    $repository = Repository::factory()
+        ->for($organization, 'organization')
+        ->github()
+        ->create(['credential_user_uuid' => $user->uuid]);
+
+    UserGitCredential::factory()
+        ->for($user, 'user')
+        ->github()
+        ->create();
+
+    $this->artisan('sync:repository', ['repository' => $repository->uuid, '--force' => true])
+        ->expectsOutput('Found 1 repository/repositories to sync.')
+        ->assertSuccessful();
+});

--- a/tests/Unit/GitProviderReadmeBaseUrlTest.php
+++ b/tests/Unit/GitProviderReadmeBaseUrlTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Domains\Repository\Contracts\Enums\GitProvider;
+
+it('appends the package directory to the README link bases', function () {
+    expect(GitProvider::GitHub->rawFileBaseUrl('acme/mono', 'abc', null, 'packages/billing'))
+        ->toBe('https://raw.githubusercontent.com/acme/mono/abc/packages/billing/')
+        ->and(GitProvider::GitHub->blobBaseUrl('acme/mono', 'abc', null, '/packages/billing/'))
+        ->toBe('https://github.com/acme/mono/blob/abc/packages/billing/')
+        ->and(GitProvider::GitLab->rawFileBaseUrl('acme/mono', 'abc', 'https://git.example.test', 'packages/billing'))
+        ->toBe('https://git.example.test/acme/mono/-/raw/abc/packages/billing/')
+        ->and(GitProvider::Bitbucket->blobBaseUrl('acme/mono', 'abc', null, 'packages/billing'))
+        ->toBe('https://bitbucket.org/acme/mono/src/abc/packages/billing/')
+        ->and(GitProvider::Git->rawFileBaseUrl('git@example.test:acme/mono.git', 'abc', null, 'packages/billing'))
+        ->toBeNull();
+});
+
+it('keeps the repository root as the base without a directory', function () {
+    expect(GitProvider::GitHub->rawFileBaseUrl('acme/mono', 'abc'))
+        ->toBe('https://raw.githubusercontent.com/acme/mono/abc/')
+        ->and(GitProvider::GitHub->blobBaseUrl('acme/mono', 'abc', null, null))
+        ->toBe('https://github.com/acme/mono/blob/abc/');
+});

--- a/tests/Unit/PackagePathPatternTest.php
+++ b/tests/Unit/PackagePathPatternTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Domains\Repository\Services\PackagePaths\PackagePathPattern;
+
+it('normalizes surrounding whitespace and slashes', function () {
+    expect(PackagePathPattern::normalize(' /packages/billing/ '))->toBe('packages/billing')
+        ->and(PackagePathPattern::normalize('packages//billing'))->toBe('packages/billing')
+        ->and(PackagePathPattern::normalize('./packages/*'))->toBe('packages/*')
+        ->and(PackagePathPattern::normalize('.'))->toBe('.')
+        ->and(PackagePathPattern::normalize('/'))->toBe('.')
+        ->and(PackagePathPattern::normalize('./'))->toBe('.')
+        ->and(PackagePathPattern::normalize(''))->toBe('');
+});
+
+it('accepts directories, single-level wildcards and the root', function () {
+    foreach (['packages/billing', 'packages/*', '*', '.', '/', 'src/Symfony/Component/Console', 'lib_v2/pkg-1.0'] as $pattern) {
+        expect(PackagePathPattern::isValid($pattern))->toBeTrue($pattern);
+    }
+});
+
+it('rejects traversal, nested wildcards and unsafe characters', function () {
+    foreach (['', '../x', 'packages/../x', 'packages/*/src', 'packages/**', 'a b', 'packages/bil ling', "x\0y", 'packages/*x'] as $pattern) {
+        expect(PackagePathPattern::isValid($pattern))->toBeFalse($pattern);
+    }
+});
+
+it('identifies wildcards and their parent directory', function () {
+    expect(PackagePathPattern::isWildcard('packages/*'))->toBeTrue()
+        ->and(PackagePathPattern::isWildcard('*'))->toBeTrue()
+        ->and(PackagePathPattern::isWildcard('packages/billing'))->toBeFalse()
+        ->and(PackagePathPattern::wildcardParent('packages/*'))->toBe('packages')
+        ->and(PackagePathPattern::wildcardParent('src/packages/*'))->toBe('src/packages')
+        ->and(PackagePathPattern::wildcardParent('*'))->toBe('');
+});
+
+it('matches package directories against patterns', function () {
+    expect(PackagePathPattern::matches('.', null))->toBeTrue()
+        ->and(PackagePathPattern::matches('.', ''))->toBeTrue()
+        ->and(PackagePathPattern::matches('.', 'packages/billing'))->toBeFalse()
+        ->and(PackagePathPattern::matches('packages/*', 'packages/billing'))->toBeTrue()
+        ->and(PackagePathPattern::matches('packages/*', 'packages/billing/sub'))->toBeFalse()
+        ->and(PackagePathPattern::matches('packages/*', 'other/billing'))->toBeFalse()
+        ->and(PackagePathPattern::matches('packages/*', null))->toBeFalse()
+        ->and(PackagePathPattern::matches('*', 'billing'))->toBeTrue()
+        ->and(PackagePathPattern::matches('*', 'packages/billing'))->toBeFalse()
+        ->and(PackagePathPattern::matches('packages/billing', 'packages/billing'))->toBeTrue()
+        ->and(PackagePathPattern::matches('packages/billing', 'packages/billing2'))->toBeFalse()
+        ->and(PackagePathPattern::anyMatches(['.', 'packages/*'], 'packages/crm'))->toBeTrue()
+        ->and(PackagePathPattern::anyMatches(['packages/*'], null))->toBeFalse();
+});


### PR DESCRIPTION
Second part of monorepo support, stacked on #185. The sync pipeline now reads every configured package directory per ref; repositories without configured paths behave as before.

- `ResolvePackagePathsAction` and `PackagePathPattern` turn `repositories.package_paths` (literal directories, a single trailing `*`, `.` for the root) into directories per ref, expanding wildcards through the provider's directory listing. The root is synced only when `.` is listed.
- `SyncRefAction` loops over those directories and returns `SyncRefResultData`. An invalid `composer.json` in one directory no longer skips the whole ref. After a successful pass, versions of this repository's other packages for that ref are removed; directories whose `composer.json` failed to parse are left alone. This cleanup applies to single-package repositories too (changelog entry).
- `FindOrCreatePackageAction` stores the source path, records `PackageCreated`, and refuses names owned by another repository or a mirror instead of silently attaching versions to them.
- README lookup uses one directory listing instead of probing up to seven filenames; README links resolve against the package directory. `FilterChangedRefsAction` keeps a ref while any package's row is at a stale commit, and `SyncRepositoryJob` gained a `force` flag (`sync:repository --force`).
- Composer metadata omits the `source` block for subdirectory versions, since Composer cannot install a subdirectory from a git checkout.